### PR TITLE
fix(validation): disable running validation when a mutation is ongoing

### DIFF
--- a/src/data-workspace/validation/use-validation-result.js
+++ b/src/data-workspace/validation/use-validation-result.js
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useIsMutating, useQueries } from 'react-query'
+import { useQueries } from 'react-query'
 import {
     useApiAttributeParams,
     useDataSetId,
@@ -30,13 +30,10 @@ export const useValidationResult = () => {
     })
     const validationMetaDataQueryKey = getValidationMetaDataQueryKey(dataSetId)
 
-    const activeMutations = useIsMutating({ mutationKey: validationQueryKey })
-    const enabled = activeMutations === 0
-
     const results = useQueries({
         queries: [
-            { queryKey: validationQueryKey, enabled },
-            { queryKey: validationMetaDataQueryKey, enabled },
+            { queryKey: validationQueryKey },
+            { queryKey: validationMetaDataQueryKey },
         ],
     })
 

--- a/src/data-workspace/validation/validation-results-sidebar.js
+++ b/src/data-workspace/validation/validation-results-sidebar.js
@@ -1,11 +1,13 @@
 import i18n from '@dhis2/d2-i18n'
 import { Button, CircularLoader, NoticeBox } from '@dhis2/ui'
 import React from 'react'
+import { useIsMutating } from 'react-query'
 import {
     Sidebar,
     Title,
     SidebarProps,
     useFormChangedSincePanelOpenedContext,
+    useDataValueSetQueryKey,
 } from '../../shared/index.js'
 import { useValidationResult } from './use-validation-result.js'
 import ValidationCommentsViolations from './validation-comments-violations.js'
@@ -25,6 +27,13 @@ export default function ValidationResultsSidebar({ hide }) {
         refetch,
     } = useValidationResult()
     const showLoader = isLoading || isRefetching
+
+    const queryKey = useDataValueSetQueryKey()
+    const activeMutations = useIsMutating({
+        mutationKey: queryKey,
+    })
+
+    const hasRunningMutations = activeMutations > 0
 
     const isEmpty =
         validationRuleViolations &&
@@ -54,7 +63,7 @@ export default function ValidationResultsSidebar({ hide }) {
                 )}
                 <div className={styles.buttons}>
                     <Button
-                        disabled={showLoader}
+                        disabled={showLoader || hasRunningMutations}
                         small
                         onClick={rerunValidation}
                     >


### PR DESCRIPTION
implements [TECH-1289](https://dhis2.atlassian.net/browse/TECH-1289)

Changes in this PR 
---

Disable running and re-running validation when there is an ongoing mutation.

In this PR, I am using [useDataValueSetQueryKey](https://github.com/dhis2/data-entry-app/blob/development/src/shared/use-data-value-set/use-data-value-set-query-key.js#L5) as the mutation key, which is used internally by [useDataValueMutation](https://github.com/dhis2/data-entry-app/blob/e327a277ff754c9de3167115fb1084143fa324bc/src/data-workspace/use-data-value-mutation/use-data-value-mutation.js#L11). [This other bit](https://github.com/dhis2/data-entry-app/blob/e327a277ff754c9de3167115fb1084143fa324bc/src/bottom-bar/main-tool-bar.js#L13) that is related and unchanged.

**Note**: This PR is a continuation of [this discussion](https://github.com/dhis2/data-entry-app/pull/93#discussion_r930139503).

