### PR TITLE
chore: use logical CSS properties instead of physical properties throughout the app

### DIFF
--- a/src/app/load-app.module.css
+++ b/src/app/load-app.module.css
@@ -1,3 +1,3 @@
 .center {
-    margin-top: var(--spacers-dp48)
+    margin-block-start: var(--spacers-dp48)
 }

--- a/src/bottom-bar/data-item-bar.module.css
+++ b/src/bottom-bar/data-item-bar.module.css
@@ -2,12 +2,12 @@
     display: flex;
     padding: 4px 12px;
     align-items: center;
-    border-bottom: 1px solid var(--colors-grey400);
+    border-block-end: 1px solid var(--colors-grey400);
 }
 
 .name {
     display: block;
-    margin-right: 8px;
+    margin-inline-end: 8px;
     font-size: 13px;
     line-height: 15px;
     color: var(--colors-grey800);

--- a/src/bottom-bar/main-tool-bar.module.css
+++ b/src/bottom-bar/main-tool-bar.module.css
@@ -6,7 +6,7 @@
 
 .toolbarItem {
     display: flex;
-    margin-right: 12px;
+    margin-inline-end: 12px;
 }
 
 .toolbarItem:last-child {
@@ -14,12 +14,12 @@
      * This way we avoid a break/overflow when the
      * margin would "spill over" otherwise
      */
-    margin-right: 0;
+    margin-inline-end: 0;
 }
 
 .icon {
     display: block;
-    margin-right: 4px;
+    margin-inline-end: 4px;
     height: 16px;
     width: 16px;
 }

--- a/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.module.css
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.module.css
@@ -4,13 +4,13 @@
 }
 
 .inputs {
-    margin-bottom: 32px;
+    margin-block-end: 32px;
 }
 
 .input {
-    margin-bottom: 16px;
+    margin-block-end: 16px;
 }
 
 .input:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
 }

--- a/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.module.css
+++ b/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.module.css
@@ -8,9 +8,9 @@
 }
 
 .searchInputContainer {
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--colors-grey300);
-    margin-bottom: 8px;
+    padding-block-end: 4px;
+    border-block-end: 1px solid var(--colors-grey300);
+    margin-block-end: 8px;
     flex-grow: 0;
 }
 

--- a/src/context-selection/period-selector-bar-item/year-navigator.module.css
+++ b/src/context-selection/period-selector-bar-item/year-navigator.module.css
@@ -3,7 +3,7 @@
     align-items: center;
     justify-content: center;
     padding: var(--spacers-dp4) 0;
-    border-bottom: 1px solid var(--colors-grey300);
+    border-block-end: 1px solid var(--colors-grey300);
 }
 
 .year {
@@ -11,6 +11,6 @@
     color: var(--colors-grey900);
     font-size: 16px;
     line-height: 19px;
-    margin-left: var(--spacers-dp8);
-    margin-right: var(--spacers-dp8);
+    margin-inline-start: var(--spacers-dp8);
+    margin-inline-end: var(--spacers-dp8);
 }

--- a/src/data-workspace/data-details-sidebar/audit-log.module.css
+++ b/src/data-workspace/data-details-sidebar/audit-log.module.css
@@ -12,7 +12,7 @@
 }
 
 .entry {
-    margin-bottom: var(--spacers-dp8);
+    margin-block-end: var(--spacers-dp8);
 }
 
 .entry::marker {
@@ -26,7 +26,7 @@
 
 .entryMessage {
     color: var(--colors-grey900);
-    margin-right: var(--spacers-dp4);
+    margin-inline-end: var(--spacers-dp4);
 }
 
 .entryTimeAgo {

--- a/src/data-workspace/data-details-sidebar/basic-information.module.css
+++ b/src/data-workspace/data-details-sidebar/basic-information.module.css
@@ -1,11 +1,11 @@
 .unit {
     padding: var(--spacers-dp16);
-    border-bottom: 1px solid var(--colors-grey400);
+    border-block-end: 1px solid var(--colors-grey400);
 }
 
 .title {
     margin: 0;
-    margin-bottom: var(--spacers-dp16);
+    margin-block-end: var(--spacers-dp16);
     padding: 0;
     font-size: 16px;
     line-height: 21px;
@@ -23,7 +23,7 @@
     font-size: 14px;
     line-height: 18px;
     color: var(--colors-grey700);
-    margin-bottom: var(--spacers-dp8);
+    margin-block-end: var(--spacers-dp8);
 }
 
 .markedForFollowup {

--- a/src/data-workspace/data-details-sidebar/comment.module.css
+++ b/src/data-workspace/data-details-sidebar/comment.module.css
@@ -5,8 +5,8 @@
 }
 
 .comment {
-    padding-left: 6px;
-    border-left: 2px solid var(--colors-grey400);
+    padding-inline-start: 6px;
+    border-inline-start: 2px solid var(--colors-grey400);
     color: var(--colors-grey900);
 
     /* this is a "pre" element, so we need this */
@@ -18,5 +18,5 @@
 }
 
 .textArea {
-    margin-bottom: var(--spacers-dp12);
+    margin-block-end: var(--spacers-dp12);
 }

--- a/src/data-workspace/data-details-sidebar/limits-input.module.css
+++ b/src/data-workspace/data-details-sidebar/limits-input.module.css
@@ -1,5 +1,5 @@
 .container {
     display: inline-block;
     width: 60px;
-    margin-bottom: var(--spacers-dp12);
+    margin-block-end: var(--spacers-dp12);
 }

--- a/src/data-workspace/data-details-sidebar/limits-validation-error-message.module.css
+++ b/src/data-workspace/data-details-sidebar/limits-validation-error-message.module.css
@@ -1,5 +1,5 @@
 .container {
-    margin-bottom: 12px;
+    margin-block-end: 12px;
     font-size: 14px;
     color: var(--colors-grey600);
 }

--- a/src/data-workspace/data-details-sidebar/limits.module.css
+++ b/src/data-workspace/data-details-sidebar/limits.module.css
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
     gap: var(--spacers-dp4);
-    margin-bottom: var(--spacers-dp12);
+    margin-block-end: var(--spacers-dp12);
     font-size: 12px;
     line-height: 14px;
     color: var(--colors-grey800);
@@ -12,17 +12,17 @@
     display: inline-block;
     width: 60px;
     margin: 0 var(--spacers-dp12);
-    border-top: 1px solid var(--colors-grey400);
+    border-block-start: 1px solid var(--colors-grey400);
 }
 
 .input {
     display: inline-block;
     width: 60px;
-    margin-bottom: var(--spacers-dp12);
+    margin-block-end: var(--spacers-dp12);
 }
 
 .placeholder {
-    margin-bottom: var(--spacers-dp12);
+    margin-block-end: var(--spacers-dp12);
     font-size: 14px;
     line-height: 19px;
     color: var(--colors-grey600);
@@ -35,7 +35,7 @@
     display: inline-flex;
     flex-direction: column;
     gap: var(--spacers-dp4);
-    margin-bottom: var(--spacers-dp12);
+    margin-block-end: var(--spacers-dp12);
     text-align: center;
 }
 

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -52,28 +52,28 @@
 
 .topRightIndicator {
     position: absolute;
-    top: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
 }
 .bottomLeftIndicator {
     position: absolute;
-    bottom: 0;
-    left: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
 }
 
 .topRightTriangle {
     width: 0;
     height: 0;
-    border-top: 3px solid var(--colors-green300);
-    border-right: 3px solid var(--colors-green300);
-    border-bottom: 3px solid transparent;
-    border-left: 3px solid transparent;
+    border-block-start: 3px solid var(--colors-green300);
+    border-inline-end: 3px solid var(--colors-green300);
+    border-block-end: 3px solid transparent;
+    border-inline-start: 3px solid transparent;
 }
 .bottomLeftTriangle {
     width: 0;
     height: 0;
-    border-top: 3px solid transparent;
-    border-right: 3px solid transparent;
-    border-bottom: 3px solid var(--colors-grey600);
-    border-left: 3px solid var(--colors-grey600);
+    border-block-start: 3px solid transparent;
+    border-inline-end: 3px solid transparent;
+    border-block-end: 3px solid var(--colors-grey600);
+    border-inline-start: 3px solid var(--colors-grey600);
 }

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -30,7 +30,7 @@
 
 .mutationIndicator {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset-block-start: 0;
+  inset-inline-start: 0;
   transform: translateY(-100%);
 }

--- a/src/data-workspace/inputs/inputs.module.css
+++ b/src/data-workspace/inputs/inputs.module.css
@@ -66,12 +66,12 @@
 }
 .fileInput {
     /* Fixes extra padding at the bottom of the UI component */
-    margin-bottom: -4px;
+    margin-block-end: -4px;
 }
 .fileLink {
     color: var(--colors-grey700);
 }
 .deleteFileButton {
     composes: whiteButton;
-    margin-left: 8px;
+    margin-inline-start: 8px;
 }

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -32,7 +32,7 @@
 .description {
     color: var(--colors-grey300);
     font-size: 13px;
-    margin-top: 2px;
+    margin-block-start: 2px;
     font-weight: 300;
 }
 
@@ -47,9 +47,9 @@
     height: 100%;
     width: 100%;
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     /* Offset for 'Filter' icon and its padding */
-    padding-left: 32px;
+    padding-inline-start: 32px;
     background: none;
     border: none;
     color: var(--colors-grey900);
@@ -64,5 +64,5 @@
 }
 
 .sectionTab {
-    margin-bottom: 8px;
+    margin-block-end: 8px;
 }

--- a/src/data-workspace/table-body.module.css
+++ b/src/data-workspace/table-body.module.css
@@ -15,7 +15,7 @@
 .categoryNameHeader {
     composes: tableHeader;
     font-weight: 300;
-    text-align: right;
+    text-align: end;
 }
 
 .dataElementName {

--- a/src/data-workspace/validation/validation-comments-violations.module.css
+++ b/src/data-workspace/validation/validation-comments-violations.module.css
@@ -1,5 +1,5 @@
 .wrapper {
-    margin-top: 16px;
+    margin-block-start: 16px;
 }
 .title {
     color: var(--colors-grey900);

--- a/src/data-workspace/validation/validation-priority-group.module.css
+++ b/src/data-workspace/validation/validation-priority-group.module.css
@@ -11,9 +11,9 @@
     display: inline-block;
 }
 .priorityGroupBox {
-    margin-bottom: 12px;
-    padding-top: 8px;
-    padding-bottom: 12px;
+    margin-block-end: 12px;
+    padding-block-start: 8px;
+    padding-block-end: 12px;
     padding-inline-start: 12px;
     padding-inline-end: 8px;
     font-size: 14px;
@@ -21,7 +21,7 @@
     color: var(--colors-grey900);
 }
 .formula {
-    margin-top: 8px;
+    margin-block-start: 8px;
     font-size: 12px;
     line-height: 16px;
     color: var(--colors-grey700);

--- a/src/data-workspace/validation/validation-results-sidebar.module.css
+++ b/src/data-workspace/validation/validation-results-sidebar.module.css
@@ -39,5 +39,5 @@
 }
 
 .dataChangedNotice {
-    margin-bottom: 8px;
+    margin-block-end: 8px;
 }

--- a/src/data-workspace/validation/validation-summary-box.module.css
+++ b/src/data-workspace/validation/validation-summary-box.module.css
@@ -3,9 +3,9 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding-top: 8px;
-    padding-bottom: 8px;
-    margin-bottom: 24px;
+    padding-block-start: 8px;
+    padding-block-end: 8px;
+    margin-block-end: 24px;
 }
 
 .summaryBox :global(svg) {
@@ -13,7 +13,7 @@
 }
 
 .summaryBox .title {
-    margin-bottom: 8px;
+    margin-block-end: 8px;
     font-size: 13px;
     font-weight: 500;
     display: flex;

--- a/src/right-hand-panel/right-hand-panel.module.css
+++ b/src/right-hand-panel/right-hand-panel.module.css
@@ -1,7 +1,7 @@
 .wrapper {
     background: white;
     height: 100%;
-    border-left: 1px solid var(--colors-grey400);
+    border-inline-start: 1px solid var(--colors-grey400);
 }
 
 .portalAnchor {

--- a/src/shared/sidebar/expandable-unit.module.css
+++ b/src/shared/sidebar/expandable-unit.module.css
@@ -1,5 +1,5 @@
 .toggleableUnit {
-    border-bottom: 1px solid var(--colors-grey400);
+    border-block-end: 1px solid var(--colors-grey400);
     padding: 0;
 }
 
@@ -28,11 +28,11 @@
 
 .content {
     padding: var(--spacers-dp16);
-    padding-top: 0;
+    padding-block-start: 0;
 }
 
 .open .title {
-    padding-bottom: var(--spacers-dp16);
+    padding-block-end: var(--spacers-dp16);
 }
 
 .disabled .title {

--- a/src/shared/sidebar/sidebar.module.css
+++ b/src/shared/sidebar/sidebar.module.css
@@ -1,5 +1,5 @@
 .wrapper {
     background: white;
     min-height: 100%;
-    border-left: 1px solid var(--colors-grey400);
+    border-inline-start: 1px solid var(--colors-grey400);
 }

--- a/src/shared/sidebar/title.module.css
+++ b/src/shared/sidebar/title.module.css
@@ -3,7 +3,7 @@
     grid-template-columns: 1fr auto;
     align-items: center;
     min-height: 44px;
-    padding-left: var(--spacers-dp16);
+    padding-inline-start: var(--spacers-dp16);
     background: var(--colors-grey300);
 }
 


### PR DESCRIPTION
implements [TECH-1294](https://dhis2.atlassian.net/browse/TECH-1294)

### Changes in this PR

Use logical CSS properties instead of physical properties to make localisation to right-to-left (and vertical) languages easier. 

#### Background and useful links

- [Mapping for margins and borders](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Margins_borders_padding#mappings_for_margins_borders_and_padding)

- [Mapping for floating and positions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Floating_and_positioning)

- Browser support - https://caniuse.com/css-logical-props

- [Why we need logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts#why_do_we_need_logical_properties)

#### Note

A followup PR will enforce the use of logical operators in CI checks