### PR TITLE
fix: post only once when boolean radio is cleared

### DIFF
--- a/src/data-workspace/inputs/boolean-radios.js
+++ b/src/data-workspace/inputs/boolean-radios.js
@@ -127,10 +127,6 @@ export const BooleanRadios = ({
                     syncData('')
                     clearField.input.onBlur()
                 }}
-                onBlur={() => {
-                    handleBlur() // Probably handled by onClick, but included here for safety
-                    clearField.input.onBlur()
-                }}
                 onKeyDown={onKeyDown}
                 disabled={disabled}
             >

--- a/src/data-workspace/inputs/boolean-radios.test.js
+++ b/src/data-workspace/inputs/boolean-radios.test.js
@@ -1,0 +1,88 @@
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { useField } from 'react-final-form'
+import { render } from '../../test-utils/render.js'
+import { useSetDataValueMutation } from '../use-data-value-mutation/use-set-data-value-mutation.js'
+import { BooleanRadios } from './boolean-radios.js'
+
+jest.mock('react-final-form')
+jest.mock('../use-data-value-mutation/use-set-data-value-mutation.js')
+
+describe('boolean-radios', () => {
+    const props = {
+        fieldname: 'DgnwZliJuh5.HllvX50cXC0',
+        deId: 'DgnwZliJuh5',
+        cocId: 'HllvX50cXC0',
+        disabled: false,
+        setSyncStatus: jest.fn(),
+        onFocus: jest.fn(),
+        onKeyDown: jest.fn(),
+    }
+
+    const mutate = jest.fn()
+
+    const mockUseField = (value) => {
+        useField.mockImplementation(() => {
+            return {
+                input: {
+                    name: 'DgnwZliJuh5.HllvX50cXC0',
+                    value,
+                    onFocus: jest.fn(),
+                    onChange: jest.fn(),
+                    onBlur: jest.fn(),
+                },
+                meta: {
+                    active: false,
+                    data: {},
+                    dirty: true,
+                    dirtySinceLastSubmit: false,
+                    initial: '',
+                    invalid: false,
+                    modified: true,
+                    modifiedSinceLastSubmit: false,
+                    pristine: true,
+                    submitFailed: false,
+                    submitSucceeded: false,
+                    submitting: false,
+                    touched: true,
+                    valid: true,
+                    validating: false,
+                    visited: true,
+                },
+            }
+        })
+    }
+    beforeEach(() => {
+        useSetDataValueMutation.mockReturnValue({
+            mutate,
+        })
+    })
+
+    afterEach(jest.clearAllMocks)
+
+    it('should show Clear button if Yes is selected', () => {
+        mockUseField('true')
+        const { getByText } = render(<BooleanRadios {...props} />)
+        expect(getByText('Clear')).not.toHaveClass('hidden')
+    })
+    it('should show Clear button if No is selected', () => {
+        mockUseField('false')
+        const { getByText } = render(<BooleanRadios {...props} />)
+        expect(getByText('Clear')).not.toHaveClass('hidden')
+    })
+    it('should NOT show Clear button if nothing is selected', () => {
+        mockUseField('')
+        const { getByText } = render(<BooleanRadios {...props} />)
+        expect(getByText('Clear')).toHaveClass('hidden')
+    })
+    it('should sync ONCE when Clear button is clicked', async () => {
+        mockUseField('false')
+        const { getByText } = render(<BooleanRadios {...props} />)
+        const clearButton = getByText('Clear')
+        userEvent.click(clearButton)
+        clearButton.blur() // to simulate the bug where Clear is triggered twice (once on Click, and the other on blur)
+
+        expect(mutate).toHaveBeenCalledTimes(1)
+        expect(mutate).toHaveBeenCalledWith({ value: '' }, expect.anything())
+    })
+})


### PR DESCRIPTION
implements [TECH-1338](https://dhis2.atlassian.net/browse/TECH-1338)

### Changes in this PR
We had an extra handler for `onBlur` that caused the boolean radio to sync twice. It's unnecessary to have it so it's removed in this PR.