### PR TITLE
fix: change radio button to sync on change rather than on blur

### DIFF
--- a/src/data-workspace/inputs/boolean-radios.js
+++ b/src/data-workspace/inputs/boolean-radios.js
@@ -54,7 +54,12 @@ export const BooleanRadios = ({
         subscription: { value: true },
     })
 
-    const [lastSyncedValue, setLastSyncedValue] = useState()
+    const {
+        input: { value: fieldvalue },
+        meta,
+    } = useField(fieldname)
+    const [lastSyncedValue, setLastSyncedValue] = useState(fieldvalue)
+
     const { mutate } = useSetDataValueMutation({ deId, cocId })
     const syncData = (value) => {
         // todo: Here's where an error state could be set: ('onError')
@@ -73,16 +78,10 @@ export const BooleanRadios = ({
     const clearButtonProps = convertCallbackSignatures(clearField.input)
     delete clearButtonProps.type
 
-    const {
-        input: { value: fieldvalue },
-        meta,
-    } = useField(fieldname)
-
-    const handleBlur = () => {
-        const { dirty, valid } = meta
-        const value = fieldvalue || ''
+    const handleChange = (value) => {
+        const { valid } = meta
         // If this value has changed, sync it to server if valid
-        if (dirty && valid && value !== lastSyncedValue) {
+        if (valid && value !== lastSyncedValue) {
             syncData(value)
         }
     }
@@ -94,9 +93,9 @@ export const BooleanRadios = ({
                 label={i18n.t('Yes')}
                 value={'true'}
                 {...convertCallbackSignatures(yesField.input)}
-                onBlur={(_, e) => {
-                    handleBlur()
-                    yesField.input.onBlur(e)
+                onChange={(_, e) => {
+                    handleChange('true')
+                    yesField.input.onChange(e)
                 }}
                 onKeyDown={onKeyDown}
                 disabled={disabled}
@@ -106,9 +105,9 @@ export const BooleanRadios = ({
                 label={i18n.t('No')}
                 value={'false'}
                 {...convertCallbackSignatures(noField.input)}
-                onBlur={(_, e) => {
-                    handleBlur()
-                    noField.input.onBlur(e)
+                onChange={(_, e) => {
+                    handleChange('false')
+                    noField.input.onChange(e)
                 }}
                 onKeyDown={onKeyDown}
                 disabled={disabled}


### PR DESCRIPTION
fixes [TECH-1353](https://dhis2.atlassian.net/browse/TECH-1353)

### Changes in this PR 

**Before the change**: for boolean radios, when a user clicks an option (yes or no), then immediately clicks the `clear` button, two POSTs are sent simultaneously one with the selected value, and another with the `empty value` from the Clear. This results in a race condition between the two POSTs and the result is not predictable.

Syncing on `blur` is a needed optimisation when it comes to input fields (we don't want to be syncing every character as the user types) but for inputs that just have a single action, it would be more user-friendly to sync the action immediately (same as we do with the clear button).

**After the change**: the sync of the radio buttons happens on click. This fixes the race condition issue, and more inline with what the user would expect - once they click yes or no, that value should be saved (not only when they tab to the next field).

(note: this behaviour is also inline with the other component with a `clear` button - the option set component)