### PR TITLE
fix: sync value when editing a field to its original value

### DIFF
--- a/src/data-workspace/inputs/generic-input.js
+++ b/src/data-workspace/inputs/generic-input.js
@@ -65,8 +65,8 @@ export const GenericInput = ({
     const handleBlur = () => {
         const { value } = input
         const formattedValue = formatValue(value)
-        const { dirty, valid } = meta
-        if (dirty && valid && formattedValue !== lastSyncedValue) {
+        const { valid } = meta
+        if (valid && formattedValue !== lastSyncedValue) {
             syncData(formattedValue)
         }
     }

--- a/src/data-workspace/inputs/long-text.js
+++ b/src/data-workspace/inputs/long-text.js
@@ -17,7 +17,7 @@ export const LongText = ({
         subscription: { value: true, dirty: true, valid: true },
     })
 
-    const [lastSyncedValue, setLastSyncedValue] = useState()
+    const [lastSyncedValue, setLastSyncedValue] = useState(input.value)
     const { mutate } = useSetDataValueMutation({ deId, cocId })
     const syncData = (value) => {
         // todo: Here's where an error state could be set: ('onError')
@@ -35,8 +35,8 @@ export const LongText = ({
 
     const handleBlur = () => {
         const { value } = input
-        const { dirty, valid } = meta
-        if (dirty && valid && value !== lastSyncedValue) {
+        const { valid } = meta
+        if (valid && value !== lastSyncedValue) {
             syncData(value)
         }
     }

--- a/src/data-workspace/inputs/option-set.js
+++ b/src/data-workspace/inputs/option-set.js
@@ -21,7 +21,7 @@ export const OptionSet = ({
     const { input } = useField(fieldname, { subscription: { value: true } })
     const { data: metadata } = useMetadata()
 
-    const [lastSyncedValue, setLastSyncedValue] = useState()
+    const [lastSyncedValue, setLastSyncedValue] = useState(input.value)
     const { mutate } = useSetDataValueMutation({ deId, cocId })
     const syncData = (value) => {
         // todo: Here's where an error state could be set: ('onError')

--- a/src/data-workspace/inputs/true-only-checkbox.js
+++ b/src/data-workspace/inputs/true-only-checkbox.js
@@ -19,7 +19,7 @@ export const TrueOnlyCheckbox = ({
         subscription: { value: true, dirty: true, valid: true },
     })
 
-    const [lastSyncedValue, setLastSyncedValue] = useState()
+    const [lastSyncedValue, setLastSyncedValue] = useState(input.value)
     const { mutate } = useSetDataValueMutation({ deId, cocId })
     const syncData = (value) => {
         // todo: Here's where an error state could be set: ('onError')
@@ -39,8 +39,8 @@ export const TrueOnlyCheckbox = ({
     const handleBlur = () => {
         // For 'True only', can only send 'true' (or '1') or ''
         const value = input.checked ? 'true' : ''
-        const { dirty, valid } = meta
-        if (dirty && valid && value !== lastSyncedValue) {
+        const { valid } = meta
+        if (valid && value !== lastSyncedValue) {
             syncData(value)
         }
     }


### PR DESCRIPTION
fixes [TECH-1397](https://dhis2.atlassian.net/browse/TECH-1397)

### Context

Before this change, if you edit a value from its original value `x` to another value `y` then back to the original value `x`, the last change does not cause a sync. This is because we were relying on `dirty` from React-Final-Form (RFF) to decide whether to sync or not, but `dirty` is [not set to true when the value is changed back to the initial value of the form](https://final-form.org/docs/final-form/types/FormState#dirty).

### Changes in this PR

- we now use what is, in effect, our own implementation of `dirty` where we compare the `lastSyncedValue` with the current value, and drop the use of `dirty` from RFF.

- `lastSyncedValue` also had a bug with some field types, where we were not setting the initial value of the field when it's loaded. This is also fixed in this PR