### PR TITLE
fix(validation): fall back to show rule display name when there is no instruction

### DIFF
--- a/src/data-workspace/validation/validation-priority-group.js
+++ b/src/data-workspace/validation/validation-priority-group.js
@@ -49,12 +49,15 @@ const ValidationPriortyGroup = ({ level, validationViolations = [] }) => {
                 </h1>
             </div>
             {validationViolations.map((validationRule) => {
+                const violationTitle =
+                    validationRule.metaData.displayInstruction ||
+                    validationRule.metaData.displayName
                 return (
                     <div
                         className={validationViolationBoxStyle}
                         key={validationRule.metaData.id}
                     >
-                        <div>{validationRule.metaData.displayInstruction}</div>
+                        <div>{violationTitle}</div>
                         <div className={styles.formula}>
                             <ValidationRuleExpression
                                 validationRule={validationRule}

--- a/src/data-workspace/validation/validation-results-sidebar.test.js
+++ b/src/data-workspace/validation/validation-results-sidebar.test.js
@@ -238,6 +238,41 @@ describe('ValidationResultsSidebar', () => {
         await waitForLoaderToDisappear()
         expect(getByText('No validation alerts for this data.')).toBeDefined()
     })
+
+    it('should fallback to validation rule name if instruction is missing', async () => {
+        const overrideOptions = {
+            'validation/dataSet/BfMAe6Itzgt': () => ({
+                validationRuleViolations: [
+                    {
+                        validationRule: {
+                            id: 'O7I6pSSF79K',
+                            name: 'Penta3, Exclusive breastfeeding, <1 year Outreach',
+                        },
+                    },
+                ],
+                commentRequiredViolations: [],
+            }),
+            validationRules: () => ({
+                validationRules: [
+                    {
+                        importance: 'MEDIUM',
+                        operator: 'less_than_or_equal_to',
+                        displayName:
+                            'fallback display name since there is no instruction',
+                        id: 'O7I6pSSF79K',
+                        leftSide: { displayDescription: '' },
+                        rightSide: { displayDescription: '' },
+                    },
+                ],
+            }),
+        }
+        const { getByText } = renderComponent(overrideOptions)
+
+        await waitForLoaderToDisappear()
+        expect(
+            getByText('fallback display name since there is no instruction')
+        ).toBeDefined()
+    })
 })
 
 const validationMetadataMockResponse = {


### PR DESCRIPTION
fixes [TECH-1400](https://dhis2.atlassian.net/browse/TECH-1400)

### Changes in this PR
we display the instruction field (`displayInstruction`) for the validation rule by default, but this is not a mandatory field. So in this PR, we add a fallback to display the validation rule display name when the instruction is not there.