### PR TITLE
fix(org unit selector preloading): respect default setting for offline org unit level

### DIFF
--- a/src/context-selection/org-unit-selector-bar-item/get-offline-levels-to-load.js
+++ b/src/context-selection/org-unit-selector-bar-item/get-offline-levels-to-load.js
@@ -1,11 +1,11 @@
 /**
- * @param {Object} data
- * @param {Object} data.organisationUnitLevels
- * @param {Integer} data.organisationUnitLevels.level
- * @param {Integer} data.organisationUnitLevels.offlineLevels
- * @param {Object} data.userOrganisationUnits
- * @param {String} data.userOrganisationUnits.id
- * @param {Integer} data.userOrganisationUnits.level
+ * @param {Object} options
+ * @param {Object} options.organisationUnitLevels
+ * @param {Integer} options.organisationUnitLevels.level
+ * @param {Integer} options.organisationUnitLevels.offlineLevels
+ * @param {Object} options.userOrganisationUnits
+ * @param {String} options.userOrganisationUnits.id
+ * @param {Integer} options.userOrganisationUnits.level
  *
  * @returns {Array.<{ id: String, offlineLevels: Int }>}
  */

--- a/src/context-selection/org-unit-selector-bar-item/load-all-offline-levels.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-all-offline-levels.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import loadOfflineLevel from './load-offline-level.js'
 
 export default function loadAllOfflineLevels({
@@ -9,6 +10,12 @@ export default function loadAllOfflineLevels({
             return loadOfflineLevel({
                 dataEngine,
                 ...offlineLevelToLoad,
+            }).catch(() => {
+                throw new Error(
+                    i18n.t("We couldn't pre-load organisation with id {{id}}", {
+                        id: offlineLevelToLoad.id,
+                    })
+                )
             })
         })
     )

--- a/src/context-selection/org-unit-selector-bar-item/load-all-offline-levels.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-all-offline-levels.js
@@ -1,0 +1,15 @@
+import loadOfflineLevel from './load-offline-level.js'
+
+export default function loadAllOfflineLevels({
+    dataEngine,
+    offlineLevelsToLoadData,
+}) {
+    return Promise.all(
+        offlineLevelsToLoadData.map((offlineLevelToLoad) => {
+            return loadOfflineLevel({
+                dataEngine,
+                ...offlineLevelToLoad,
+            })
+        })
+    )
+}

--- a/src/context-selection/org-unit-selector-bar-item/load-default-offline-levels.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-default-offline-levels.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import loadAllOfflineLevels from './load-all-offline-levels.js'
 
 // load paths from user's roots to the default level
@@ -7,17 +8,41 @@ export default async function loadDefaultOfflineLevels({
     configOfflineOrgUnitLevel,
 }) {
     if (!userOrganisationUnits) {
-        return Promise.resolve()
+        return Promise.reject(
+            new Error(
+                i18n.t(
+                    "We couldn't pre-load organisation units for offline usage. Your user account is not assigned to any organisation unit. Please contact an administrator."
+                )
+            )
+        )
+    }
+
+    if (!configOfflineOrgUnitLevel?.level) {
+        return Promise.reject(
+            new Error(
+                i18n.t(
+                    "We couldn't pre-load organisation units for offline usage. The default organisation unit offline level has not been configured. Please contact an administrator."
+                )
+            )
+        )
     }
 
     const offlineLevelsToLoadData = userOrganisationUnits
         .filter(({ level }) => level < configOfflineOrgUnitLevel.level)
-        .map(({ id, level }) => {
-            return {
-                id,
-                offlineLevels: configOfflineOrgUnitLevel.level - level,
-            }
-        })
+        .map(({ id, level }) => ({
+            id,
+            offlineLevels: configOfflineOrgUnitLevel.level - level,
+        }))
+
+    if (!offlineLevelsToLoadData.length) {
+        return Promise.reject(
+            new Error(
+                i18n.t(
+                    "We couldn't pre-load organisation units for offline usage. The default organisation unit offline level is lower than the level of the organisation unit(s) assigned to you."
+                )
+            )
+        )
+    }
 
     return loadAllOfflineLevels({ dataEngine, offlineLevelsToLoadData })
 }

--- a/src/context-selection/org-unit-selector-bar-item/load-default-offline-levels.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-default-offline-levels.js
@@ -1,0 +1,23 @@
+import loadAllOfflineLevels from './load-all-offline-levels.js'
+
+// load paths from user's roots to the default level
+export default async function loadDefaultOfflineLevels({
+    dataEngine,
+    userOrganisationUnits,
+    configOfflineOrgUnitLevel,
+}) {
+    if (!userOrganisationUnits) {
+        return Promise.resolve()
+    }
+
+    const offlineLevelsToLoadData = userOrganisationUnits
+        .filter(({ level }) => level < configOfflineOrgUnitLevel.level)
+        .map(({ id, level }) => {
+            return {
+                id,
+                offlineLevels: configOfflineOrgUnitLevel.level - level,
+            }
+        })
+
+    return loadAllOfflineLevels({ dataEngine, offlineLevelsToLoadData })
+}

--- a/src/context-selection/org-unit-selector-bar-item/load-offline-level.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-offline-level.js
@@ -15,31 +15,17 @@ export default async function loadOfflineLevel({
     id,
     offlineLevels,
 }) {
-    let orgData
-
-    try {
-        orgData = await loadOrgUnit(dataEngine, id)
-    } catch (e) {
-        // @TODO: Figure out what to do when loading fails
-        return
-    }
-
+    const orgData = await loadOrgUnit(dataEngine, id)
     const { children: childrenSize } = orgData.orgUnit
     const nextOfflineLevels = offlineLevels - 1
 
     if (!childrenSize) {
-        return
+        return Promise.resolve()
     }
 
-    let orgChildren
-    try {
-        orgChildren = await dataEngine.query(QUERY_ORG_CHILDREN_FROM_UI, {
-            variables: { id },
-        })
-    } catch (e) {
-        // @TODO: Figure out what to do when loading fails
-        return
-    }
+    const orgChildren = await dataEngine.query(QUERY_ORG_CHILDREN_FROM_UI, {
+        variables: { id },
+    })
 
     const children = orgChildren.orgUnit.children
 
@@ -57,4 +43,6 @@ export default async function loadOfflineLevel({
             })
         }
     }
+
+    return Promise.resolve()
 }

--- a/src/context-selection/org-unit-selector-bar-item/load-offline-level.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-offline-level.js
@@ -1,14 +1,4 @@
-// Copied from https://github.com/dhis2/ui/blob/master/components/organisation-unit-tree/src/organisation-unit-node/use-org-data/use-org-data.js
-export const QUERY_ORG_UNIT_FROM_UI = {
-    orgUnit: {
-        resource: `organisationUnits`,
-        id: ({ id }) => id,
-        params: ({ isUserDataViewFallback }) => ({
-            isUserDataViewFallback,
-            fields: ['path', 'children::size'],
-        }),
-    },
-}
+import loadOrgUnit from './load-org-unit.js'
 
 export const QUERY_ORG_CHILDREN_FROM_UI = {
     orgUnit: {
@@ -25,13 +15,10 @@ export default async function loadOfflineLevel({
     id,
     offlineLevels,
 }) {
-    const variables = { id }
     let orgData
 
     try {
-        orgData = await dataEngine.query(QUERY_ORG_UNIT_FROM_UI, {
-            variables,
-        })
+        orgData = await loadOrgUnit(dataEngine, id)
     } catch (e) {
         // @TODO: Figure out what to do when loading fails
         return
@@ -47,7 +34,7 @@ export default async function loadOfflineLevel({
     let orgChildren
     try {
         orgChildren = await dataEngine.query(QUERY_ORG_CHILDREN_FROM_UI, {
-            variables,
+            variables: { id },
         })
     } catch (e) {
         // @TODO: Figure out what to do when loading fails

--- a/src/context-selection/org-unit-selector-bar-item/load-offline-level.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-offline-level.js
@@ -26,9 +26,17 @@ export default async function loadOfflineLevel({
     offlineLevels,
 }) {
     const variables = { id }
-    const orgData = await dataEngine.query(QUERY_ORG_UNIT_FROM_UI, {
-        variables,
-    })
+    let orgData
+
+    try {
+        orgData = await dataEngine.query(QUERY_ORG_UNIT_FROM_UI, {
+            variables,
+        })
+    } catch (e) {
+        // @TODO: Figure out what to do when loading fails
+        return
+    }
+
     const { children: childrenSize } = orgData.orgUnit
     const nextOfflineLevels = offlineLevels - 1
 
@@ -36,9 +44,15 @@ export default async function loadOfflineLevel({
         return
     }
 
-    const orgChildren = await dataEngine.query(QUERY_ORG_CHILDREN_FROM_UI, {
-        variables,
-    })
+    let orgChildren
+    try {
+        orgChildren = await dataEngine.query(QUERY_ORG_CHILDREN_FROM_UI, {
+            variables,
+        })
+    } catch (e) {
+        // @TODO: Figure out what to do when loading fails
+        return
+    }
 
     const children = orgChildren.orgUnit.children
 

--- a/src/context-selection/org-unit-selector-bar-item/load-offline-level.test.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-offline-level.test.js
@@ -1,7 +1,7 @@
 import loadOfflineLevel, {
-    QUERY_ORG_UNIT_FROM_UI,
     QUERY_ORG_CHILDREN_FROM_UI,
 } from './load-offline-level.js'
+import { QUERY_ORG_UNIT_FROM_UI } from './load-org-unit.js'
 
 describe('loadOfflineLevel', () => {
     const query = jest.fn()

--- a/src/context-selection/org-unit-selector-bar-item/load-org-unit.js
+++ b/src/context-selection/org-unit-selector-bar-item/load-org-unit.js
@@ -1,0 +1,18 @@
+// Copied from https://github.com/dhis2/ui/blob/master/components/organisation-unit-tree/src/organisation-unit-node/use-org-data/use-org-data.js
+export const QUERY_ORG_UNIT_FROM_UI = {
+    orgUnit: {
+        resource: `organisationUnits`,
+        id: ({ id }) => id,
+        params: ({ isUserDataViewFallback }) => ({
+            isUserDataViewFallback,
+            fields: ['path', 'children::size'],
+        }),
+    },
+}
+
+export default function loadOrgUnit(dataEngine, id) {
+    const variables = { id }
+    return dataEngine.query(QUERY_ORG_UNIT_FROM_UI, {
+        variables,
+    })
+}

--- a/src/context-selection/org-unit-selector-bar-item/use-load-config-offline-org-unit-level.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-load-config-offline-org-unit-level.js
@@ -1,0 +1,5 @@
+import { useQuery } from '@tanstack/react-query'
+
+export default function useLoadConfigOfflineOrgUnitLevel() {
+    return useQuery(['configuration/offlineOrganisationUnitLevel'])
+}

--- a/src/context-selection/org-unit-selector-bar-item/use-load-offline-levels.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-load-offline-levels.js
@@ -4,24 +4,16 @@ import loadOfflineLevel from './load-offline-level.js'
 import useOfflineLevelsToLoad from './use-offline-levels-to-load.js'
 import useOrganisationUnitLevels from './use-organisation-unit-levels.js'
 
-const loadAllOfflineLevels = ({
-    dataEngine,
-    offlineLevelsToLoadData,
-    onDone,
-}) => {
-    const allRequests = offlineLevelsToLoadData.map((offlineLevelToLoad) =>
-        loadOfflineLevel({
-            dataEngine,
-            ...offlineLevelToLoad,
+function loadAllOfflineLevels({ dataEngine, offlineLevelsToLoadData }) {
+    return Promise.all(
+        offlineLevelsToLoadData.map((offlineLevelToLoad) => {
+            console.log('> loadAllOfflineLevels -> offlineLevelToLoad:', offlineLevelToLoad)
+            return loadOfflineLevel({
+                dataEngine,
+                ...offlineLevelToLoad,
+            })
         })
     )
-
-    Promise.all(allRequests).finally(() => {
-        // @TODO: Think about what should happen here
-        // Do we want to notify the user about success?
-        // What do we want to display when an error occurs?
-        onDone()
-    })
 }
 
 /**
@@ -44,7 +36,11 @@ export default function useLoadOfflineLevels() {
             loadAllOfflineLevels({
                 dataEngine,
                 offlineLevelsToLoadData,
-                onDone: () => setDone(true),
+            }).finally(() => {
+                // @TODO: Think about what should happen here
+                // Do we want to notify the user about success?
+                // What do we want to display when an error occurs?
+                setDone(true)
             })
         }
     }, [dataEngine, offlineLevelsToLoadData, setDone])

--- a/src/context-selection/org-unit-selector-bar-item/use-load-offline-levels.test.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-load-offline-levels.test.js
@@ -1,15 +1,24 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { renderHook } from '@testing-library/react-hooks'
 import loadOfflineLevel from './load-offline-level.js'
+import useLoadConfigOfflineOrgUnitLevel from './use-load-config-offline-org-unit-level.js'
 import useLoadOfflineLevels from './use-load-offline-levels.js'
 import useOfflineLevelsToLoad from './use-offline-levels-to-load.js'
 import useOrganisationUnitLevels from './use-organisation-unit-levels.js'
 
 jest.mock('@dhis2/app-runtime', () => ({
     useDataEngine: jest.fn(),
+    useAlert: jest.fn(() => ({
+        show: jest.fn(),
+    })),
 }))
 
 jest.mock('./load-offline-level.js', () => ({
+    __esModule: true,
+    default: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock('./use-load-config-offline-org-unit-level.js', () => ({
     __esModule: true,
     default: jest.fn(),
 }))
@@ -29,17 +38,23 @@ describe('useLoadOfflineLevels', () => {
     useDataEngine.mockImplementation(() => dataEngine)
 
     const offlineLevelToLoad = {
-        data: [
-            { offlineLevels: 2, id: 'foo' },
-            { offlineLevels: 1, id: 'bar' },
-        ],
+        data: {
+            offlineLevelsToLoad: [
+                { offlineLevels: 2, id: 'foo' },
+                { offlineLevels: 1, id: 'bar' },
+            ],
+            userOrganisationUnits: [],
+        },
     }
 
+    jest.spyOn(console, 'error').mockImplementation(() => null)
+    useLoadConfigOfflineOrgUnitLevel.mockImplementation(() => ({}))
     useOrganisationUnitLevels.mockImplementation(() => ({}))
     useOfflineLevelsToLoad.mockImplementation(() => offlineLevelToLoad)
 
     afterEach(() => {
         useDataEngine.mockClear(), loadOfflineLevel.mockClear()
+        useLoadConfigOfflineOrgUnitLevel.mockClear()
         useOfflineLevelsToLoad.mockClear()
         useOrganisationUnitLevels.mockClear()
     })

--- a/src/context-selection/org-unit-selector-bar-item/use-offline-levels-to-load.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-offline-levels-to-load.js
@@ -15,10 +15,17 @@ export default function useOfflineLevelsToLoad(organisationUnitLevels) {
         // Only fetch the user's org units when there are any offline levels
         enable: organisationUnitLevels?.length,
         select: ({ organisationUnits: userOrganisationUnits }) => {
-            return getOfflineLevelsToLoad({
+            return {
                 userOrganisationUnits,
-                organisationUnitLevels,
-            })
+                offlineLevelsToLoad: getOfflineLevelsToLoad({
+                    organisationUnitLevels,
+                    userOrganisationUnits,
+                }).filter(
+                    // When changing an offline level to "default",
+                    // this value is undefined and should be omitted
+                    ({ offlineLevels }) => offlineLevels
+                ),
+            }
         },
     })
 }


### PR DESCRIPTION
* If the org unit hierarchy's offline levels are set to `Default`, then the selector will now preload all levels from the user's root down to the level specified in the system settings app (which is `level: 3` in our SL db)
* If there's an error while preloading the org units in any way, we show a warning alert bar to the user

NOTE: When using the admin user, this change will cause the app to do >2k requests! I don't know any other way around this other than modifying the org unit tree component (which is somewhat time consuming as well)