### PR TITLE
fix(data-value-set): refetch only when changing context-selection

### DIFF
--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -46,9 +46,11 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
     // used to reset form-state when context-selection is changed
     const formKey = useContextSelectionId()
 
+    // to keep one stable dependency for effect below
+    const validFormKey = isValidSelection ? formKey : false
     // force refetch when context-selection changes
     useEffect(() => {
-        if (isValidSelection) {
+        if (validFormKey) {
             // note this will only refetch "active"/mounted queries,
             // so it's safe to not provide a queryKey
             queryClient.invalidateQueries(null, {
@@ -57,8 +59,7 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
                 cancelRefetch: false,
             })
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [formKey])
+    }, [validFormKey, queryClient])
 
     if (selectionHasNoFormMessage) {
         const title = i18n.t('The current selection does not have a form')

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -20,7 +20,7 @@ import {
 import styles from './data-workspace.module.css'
 import { EntryForm } from './entry-form.js'
 import { FinalFormWrapper } from './final-form-wrapper.js'
-
+import { dataValueSets as dataValueSetQueryKey } from './query-key-factory.js'
 export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
     const queryClient = useQueryClient()
     const { data: metadata } = useMetadata()
@@ -52,12 +52,16 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
     useEffect(() => {
         if (validFormKey) {
             // note this will only refetch "active"/mounted queries,
-            // so it's safe to not provide a queryKey
-            queryClient.invalidateQueries(null, {
-                // if new selection is not in cache, a fetch will already be in-flight
-                // so we do not need to send another one.
-                cancelRefetch: false,
-            })
+            // so it's safe to not provide params
+            queryClient.invalidateQueries(
+                dataValueSetQueryKey.all,
+                { type: 'active' },
+                {
+                    // if new selection is not in cache, a fetch will already be in-flight
+                    // so we do not need to send another one.
+                    cancelRefetch: false,
+                }
+            )
         }
     }, [validFormKey, queryClient])
 

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -52,7 +52,7 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
             // note this will only refetch "active"/mounted queries,
             // so it's safe to not provide a queryKey
             queryClient.invalidateQueries(null, {
-                // if new selection is not in cache, a refetch will already be in-flight
+                // if new selection is not in cache, a fetch will already be in-flight
                 // so we do not need to send another one.
                 cancelRefetch: false,
             })

--- a/src/data-workspace/query-key-factory.js
+++ b/src/data-workspace/query-key-factory.js
@@ -1,4 +1,5 @@
 export const dataValueSets = {
+    all: ['dataEntry/dataValues'],
     byIds: ({
         dataSetId,
         periodId,
@@ -14,7 +15,7 @@ export const dataValueSets = {
             cp: categoryOptionIds.join(';'),
         }
 
-        return ['dataEntry/dataValues', { params }]
+        return [...dataValueSets.all, { params }]
     },
 }
 

--- a/src/shared/use-data-value-set/use-data-value-set.js
+++ b/src/shared/use-data-value-set/use-data-value-set.js
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { createSelector } from 'reselect'
 import { useIsValidSelection } from '../use-context-selection/index.js'
 import useDataValueSetQueryKey from './use-data-value-set-query-key.js'
@@ -73,23 +73,17 @@ const select = createSelector(
 export const useDataValueSet = ({ onSuccess } = {}) => {
     const isValidSelection = useIsValidSelection()
     const queryKey = useDataValueSetQueryKey()
-    const queryClient = useQueryClient()
 
     const result = useQuery(queryKey, {
         // TODO: Disable if disconnected from DHIS2 server?
-        enabled: !queryClient.isMutating() && isValidSelection,
+        enabled: isValidSelection,
+        staleTime: Infinity,
         select: select,
         // Fetch once, no matter the network connectivity;
         // will be 'paused' if offline and the request fails.
         // Important to try the network when on offline/local DHIS2 implmnt'ns
         networkMode: 'offlineFirst',
-        refetchOnMount: (query) => {
-            // only refetch on mount if the query was just hydrated
-            // this should only happen during initial app-load.
-            // If we were to return 'false' the query would not be refetch on first mount
-            // because it's mounted with hydrated-state
-            return !!query.meta.isHydrated
-        },
+        refetchOnMount: false,
         refetchOnReconnect: false,
         meta: { persist: true },
         onSuccess,


### PR DESCRIPTION
Sorry for these back-and-forth fixes for refetching. I thought I had fixed this by not "subscribing" with `useIsMutating`-hook. But apparently if the subscribed field re-renders in the meantime between fetches - it will refetch all dataValues again. This could happen if you changed a field, then highlighted another field quickly. 

I've set the `staleTime: infinity` to have more control over refetches. Now we manually refetch whenever the form selection changes. 
Also simplified `refetchOnMount`, because this is not needed anymore due to our manual `invalidateQueries`. 