### PR TITLE
fix: update miscellaneous design issues

### DIFF
--- a/cypress/integration/context-selection/section-filter/index.js
+++ b/cypress/integration/context-selection/section-filter/index.js
@@ -79,7 +79,7 @@ When('the user selects a section', () => {
 })
 
 Then('no "all sections" option should be available', () => {
-    cy.contains('Show all sections').should('not.exist')
+    cy.contains('All sections').should('not.exist')
 })
 
 Then('that section should be selected', () => {
@@ -92,7 +92,7 @@ Then('that section should be selected', () => {
 
 Then('the "all sections" option should be selected', () => {
     cy.get('[data-test="section-filter-selector"]')
-        .contains('Show all sections')
+        .contains('All sections')
         .should('exist')
 })
 
@@ -100,7 +100,7 @@ Then('the first section should be selected by default', () => {
     // open
     cy.get('[data-test="section-filter-selector"]').click()
     // there should be no "show all" option
-    cy.contains('Show all sections').should('not.exist')
+    cy.contains('All sections').should('not.exist')
     // get the first option's text
     cy.get('[data-test="menu-select"] li:nth-child(1)')
         .invoke('text')

--- a/src/bottom-bar/data-item-bar.js
+++ b/src/bottom-bar/data-item-bar.js
@@ -3,32 +3,19 @@ import { Button } from '@dhis2/ui'
 import React from 'react'
 import { dataDetailsSidebarId } from '../data-workspace/constants.js'
 import { useRightHandPanelContext } from '../right-hand-panel/index.js'
-import { useMetadata, selectors, useHighlightedField } from '../shared/index.js'
+import { useHighlightedField } from '../shared/index.js'
 import styles from './data-item-bar.module.css'
 
 export default function DataItemBar() {
     const rightHandPanel = useRightHandPanelContext()
     const item = useHighlightedField()
-    const { data: metadata } = useMetadata()
-
-    const dataElement = selectors.getDataElementById(metadata, item.dataElement)
-    const categoryOptions = selectors.getCategoryOptionsByCategoryOptionComboId(
-        metadata,
-        item.categoryOptionCombo
-    )
-
-    // We don't want to display "default"
-    const categoryOptionComboDisplayName = categoryOptions
-        .filter(({ isDefault }) => !isDefault)
-        .map(({ displayShortName }) => displayShortName)
-        .join(', ')
 
     return (
         <div className={styles.container}>
             <span className={styles.name}>
-                {dataElement.displayName}
-                {categoryOptionComboDisplayName &&
-                    ` | ${categoryOptionComboDisplayName}`}
+                {item.displayFormName}
+                {item.categoryOptionComboName &&
+                    ` | ${item.categoryOptionComboName}`}
             </span>
 
             <Button

--- a/src/bottom-bar/main-tool-bar.js
+++ b/src/bottom-bar/main-tool-bar.js
@@ -3,6 +3,7 @@ import { Button, IconErrorFilled16, IconInfo16, colors } from '@dhis2/ui'
 import { useIsMutating } from '@tanstack/react-query'
 import cx from 'classnames'
 import React from 'react'
+import { MutationIndicator } from '../app/mutation-indicator/index.js'
 import { validationResultsSidebarId } from '../data-workspace/constants.js'
 import useRightHandPanelContext from '../right-hand-panel/use-right-hand-panel-context.js'
 import {
@@ -95,6 +96,9 @@ export default function MainToolBar() {
                     </span>
                 </span>
             )}
+            <div className={styles.mutationIndicator}>
+                <MutationIndicator />
+            </div>
         </div>
     )
 }

--- a/src/bottom-bar/main-tool-bar.module.css
+++ b/src/bottom-bar/main-tool-bar.module.css
@@ -44,3 +44,8 @@
 .completedByLabel:after {
     content: ' ';
 }
+
+.mutationIndicator {
+    margin-left: auto;
+    margin-right: var(--spacers-dp4)
+}

--- a/src/context-selection/section-filter-selector-bar-item/section-filter-selector-bar-item.js
+++ b/src/context-selection/section-filter-selector-bar-item/section-filter-selector-bar-item.js
@@ -47,7 +47,7 @@ export default function SectionFilterSelectorBarItem() {
 
     const selectableOptions = dataSet?.renderAsTabs
         ? sectionOptions
-        : [{ value: undefined, label: i18n.t('Show all sections') }].concat(
+        : [{ value: undefined, label: i18n.t('All sections') }].concat(
               ...sectionOptions
           )
 
@@ -58,7 +58,7 @@ export default function SectionFilterSelectorBarItem() {
                 value={sectionFilterValue}
                 open={open}
                 setOpen={setOpen}
-                noValueMessage={i18n.t('Show all sections')}
+                noValueMessage={i18n.t('All sections')}
             >
                 <MenuSelect
                     values={selectableOptions}

--- a/src/data-workspace/custom-form/custom-form.module.css
+++ b/src/data-workspace/custom-form/custom-form.module.css
@@ -9,7 +9,15 @@
     height: auto;
 }
 .customForm :global(td:empty) {
-    background-color: var(--colors-grey100);
+    background-color: var(--colors-grey200);
+    background-size: 8px 8px;
+    background-image: repeating-linear-gradient(
+        45deg,
+        var(--colors-grey300) 0,
+        var(--colors-grey300) 0.8px,
+        var(--colors-grey200) 0,
+        var(--colors-grey200) 50%
+    );
     cursor: not-allowed;
 }
 .customForm :global(td.dhis2-data-entry-app-custom-form-label-cell) {

--- a/src/data-workspace/data-details-sidebar/basic-information.js
+++ b/src/data-workspace/data-details-sidebar/basic-information.js
@@ -8,8 +8,21 @@ import ItemPropType from './item-prop-type.js'
 
 const BasicInformation = ({ item }) => (
     <div className={styles.unit}>
-        <h1 className={styles.title}>{item.name}</h1>
+        <h1 className={styles.title}>
+            {item.displayFormName}
+            {item.categoryOptionComboName &&
+                ` | ${item.categoryOptionComboName}`}
+        </h1>
+
         <ul className={styles.elements}>
+            {item.description && (
+                <li>
+                    {i18n.t('Description: {{- description}}', {
+                        description: item.description,
+                        nsSeparator: '-:-',
+                    })}
+                </li>
+            )}
             {item.code && (
                 <li>
                     {i18n.t('Code: {{code}}', {
@@ -19,19 +32,17 @@ const BasicInformation = ({ item }) => (
                 </li>
             )}
             <li>
-                {i18n.t('ID: {{id}}', {
+                {i18n.t('Data element ID: {{id}}', {
                     id: item.dataElement,
                     nsSeparator: '-:-',
                 })}
             </li>
-            {item.description && (
-                <li>
-                    {i18n.t('Description: {{description}}', {
-                        description: item.description,
-                        nsSeparator: '-:-',
-                    })}
-                </li>
-            )}
+            <li>
+                {i18n.t('Category option combo ID: {{id}}', {
+                    id: item.categoryOptionCombo,
+                    nsSeparator: '-:-',
+                })}
+            </li>
             <li>
                 {item.lastUpdated && (
                     <Tooltip content={item.lastUpdated.toString()}>

--- a/src/data-workspace/data-details-sidebar/basic-information.test.js
+++ b/src/data-workspace/data-details-sidebar/basic-information.test.js
@@ -30,6 +30,7 @@ describe('<BasicInformation />', () => {
             followUp: false,
             code: '',
             value: '',
+            displayFormName: 'Item name (form)',
         }
 
         const { getByRole } = render(
@@ -40,7 +41,9 @@ describe('<BasicInformation />', () => {
             />
         )
 
-        expect(getByRole('heading', { name: item.name })).toBeInTheDocument()
+        expect(
+            getByRole('heading', { name: item.displayFormName })
+        ).toBeInTheDocument()
     })
 
     it('renders the item ID', () => {

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -41,7 +41,15 @@
 }
 
 .disabled {
-    background: var(--colors-grey300);
+    background-color: var(--colors-grey200);
+    background-size: 8px 8px;
+    background-image: repeating-linear-gradient(
+        45deg,
+        var(--colors-grey300) 0,
+        var(--colors-grey300) 0.8px,
+        var(--colors-grey200) 0,
+        var(--colors-grey200) 50%
+    );
 }
 
 .invalid:not(.active) {

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -3,7 +3,6 @@ import { CenteredContent, CircularLoader, NoticeBox } from '@dhis2/ui'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { MutationIndicator } from '../app/mutation-indicator/index.js'
 import { BottomBar } from '../bottom-bar/index.js'
 import {
     useMetadata,
@@ -107,13 +106,6 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
                 </main>
 
                 <footer className={footerClasses}>
-                    <div
-                        // This div and its content will be removed
-                        // once we can display this in the headerbar
-                        className={styles.mutationIndicator}
-                    >
-                        <MutationIndicator />
-                    </div>
                     <BottomBar />
                 </footer>
             </div>

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -28,13 +28,6 @@
     position: relative;
 }
 
-.mutationIndicator {
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: translateY(-100%);
-}
-
 .formMessageBox {
     margin: var(--spacers-dp8) var(--spacers-dp12) var(--spacers-dp8) var(--spacers-dp12);
 }

--- a/src/data-workspace/table-body.module.css
+++ b/src/data-workspace/table-body.module.css
@@ -45,6 +45,15 @@
 
 .paddingCell {
     composes: tableHeader;
+    background-color: var(--colors-grey200);
+    background-size: 8px 8px;
+    background-image: repeating-linear-gradient(
+        45deg,
+        var(--colors-grey300) 0,
+        var(--colors-grey300) 0.8px,
+        var(--colors-grey200) 0,
+        var(--colors-grey200) 50%
+    );
 }
 
 .totalCell,

--- a/src/shared/highlighted-field/use-highlighted-field.js
+++ b/src/shared/highlighted-field/use-highlighted-field.js
@@ -1,14 +1,19 @@
 import { useEffect, useState } from 'react'
+import { selectors, useMetadata } from '../metadata/index.js'
 import { useDataValueSet } from '../use-data-value-set/index.js'
 import { CAN_HAVE_LIMITS_TYPES } from '../value-types.js'
 import { useHighlightedFieldIdContext } from './use-highlighted-field-context.js'
 
-function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
+function gatherHighlightedFieldData({ de, coc, dataValueSet, metadata }) {
     const dataValue = dataValueSet?.dataValues[de.id]?.[coc.id]
     const { optionSet, valueType, commentOptionSet } = de
     const canHaveLimits = optionSet
         ? false
         : CAN_HAVE_LIMITS_TYPES.includes(valueType)
+    const isDefaultCategoryCombo = selectors.getCategoryComboById(
+        metadata,
+        de.categoryCombo?.id
+    )?.isDefault
 
     if (dataValue) {
         return {
@@ -16,10 +21,14 @@ function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
             valueType,
             canHaveLimits,
             categoryOptionCombo: coc.id,
+            categoryOptionComboName: isDefaultCategoryCombo
+                ? ''
+                : coc.displayName,
             name: de.displayName,
             code: de.code,
             commentOptionSetId: commentOptionSet?.id,
             description: de.description,
+            displayFormName: de.displayFormName,
         }
     }
 
@@ -27,6 +36,7 @@ function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
         valueType,
         canHaveLimits,
         categoryOptionCombo: coc.id,
+        categoryOptionComboName: isDefaultCategoryCombo ? '' : coc.displayName,
         dataElement: de.id,
         name: de.displayName,
         lastUpdated: '',
@@ -36,15 +46,17 @@ function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
         code: null,
         commentOptionSetId: commentOptionSet?.id,
         description: de.description,
+        displayFormName: de.displayFormName,
     }
 }
 
 export default function useHighlightedField() {
     const { data: dataValueSet } = useDataValueSet()
+    const { data: metadata } = useMetadata()
     const { item } = useHighlightedFieldIdContext()
     const [currentItem, setHighlightedFieldId] = useState(() => {
         const { de, coc } = item
-        return gatherHighlightedFieldData({ de, coc, dataValueSet })
+        return gatherHighlightedFieldData({ de, coc, dataValueSet, metadata })
     })
 
     useEffect(() => {
@@ -56,10 +68,10 @@ export default function useHighlightedField() {
             coc.id !== currentItem?.categoryOptionCombo
         ) {
             setHighlightedFieldId(
-                gatherHighlightedFieldData({ de, coc, dataValueSet })
+                gatherHighlightedFieldData({ de, coc, dataValueSet, metadata })
             )
         }
-    }, [currentItem, item, dataValueSet])
+    }, [currentItem, item, dataValueSet, metadata])
 
     return currentItem
 }


### PR DESCRIPTION
### [TECH-1359](https://dhis2.atlassian.net/browse/TECH-1359) / details sidebar

This adds categoryOptionCombo information to the sidebar, uses categoryOptionCombo.displayName consistent with the old app, and rearranges dataElement.description to top of sidebar (see ticket for details)

_before_
<img width="920" alt="image" src="https://user-images.githubusercontent.com/18490902/191507070-cb9b583c-6295-4122-8f8b-7fab92057048.png">


_after_
<img width="832" alt="image" src="https://user-images.githubusercontent.com/18490902/191504317-c397ba5f-8420-4739-b6b9-bb3e0fa73b0b.png">


### [TECH-1258](https://dhis2.atlassian.net/browse/TECH-1258) / grey fields

This harmonizes/corrects the styling for default form padding cells/section form non-allowed cells (grey fields)/custom form empty cells. See ticket for more details.

Examples below comparing locked against custom form empty cells before and after.

_before_
<img width="954" alt="image" src="https://user-images.githubusercontent.com/18490902/191506345-069db7c3-7848-4429-9e6b-8c5a1a200bfb.png">

_after_
<img width="586" alt="image" src="https://user-images.githubusercontent.com/18490902/191506473-0f69639c-6e71-4525-a728-c658de8f25ff.png">


### [TECH-1423](https://dhis2.atlassian.net/browse/TECH-1423) / synced status indicator positioning

This moves the position of the synced indicator (see discussions on ticket; Lars and Phil objected to the original floating positioning)

_before_
<img width="923" alt="image" src="https://user-images.githubusercontent.com/18490902/191507272-6ca07998-e14d-4bd5-8eac-21f0e453a048.png">


_after_
<img width="778" alt="image" src="https://user-images.githubusercontent.com/18490902/191506770-1aac06ce-9436-4a51-a35d-fc242b1c697a.png">


### [TECH-1422](https://dhis2.atlassian.net/browse/TECH-1422) / All sections text

This updates "Show all sections" to "All sections" (as requested by Lars)

_before_
<img width="295" alt="image" src="https://user-images.githubusercontent.com/18490902/191506937-e71d0486-5e9b-46ed-a9d3-c29452c134a5.png">


_after_
<img width="282" alt="image" src="https://user-images.githubusercontent.com/18490902/191506808-7d195d40-93b2-477d-bc02-225d7f11b5ce.png">
