### PR TITLE
fix: rerun validation on main bar button click

### DIFF
--- a/src/bottom-bar/main-tool-bar.js
+++ b/src/bottom-bar/main-tool-bar.js
@@ -11,6 +11,7 @@ import {
     useLockedContext,
     useEntryFormStore,
     validationResultsSidebarId,
+    useValidationStore,
 } from '../shared/index.js'
 import CompleteButton from './complete-button.js'
 import styles from './main-tool-bar.module.css'
@@ -28,10 +29,13 @@ export default function MainToolBar() {
     const { data } = useDataValueSet()
 
     const validateDisabled = activeMutations > 0
+    const setValidationToRefresh = useValidationStore(
+        (store) => store.setValidationToRefresh
+    )
 
     const validate = () => {
         if (rightHandPanel.id === validationResultsSidebarId) {
-            rightHandPanel.hide()
+            setValidationToRefresh(true)
         } else {
             rightHandPanel.show(validationResultsSidebarId)
         }

--- a/src/bottom-bar/validation-results-sidebar/validation-results-sidebar.js
+++ b/src/bottom-bar/validation-results-sidebar/validation-results-sidebar.js
@@ -10,6 +10,7 @@ import {
     useValueStore,
     useIsFirstRender,
     useValidationResult,
+    useValidationStore,
 } from '../../shared/index.js'
 import ValidationCommentsViolations from './validation-comments-violations.js'
 import { validationLevels } from './validation-config.js'
@@ -39,6 +40,20 @@ export default function ValidationResultsSidebar({ hide }) {
     } = useValidationResult()
     const showLoader = isLoading || isRefetching
 
+    const shouldValidationRefresh = useValidationStore((store) =>
+        store.getValidationToRefresh()
+    )
+    const setValidationToRefresh = useValidationStore(
+        (store) => store.setValidationToRefresh
+    )
+
+    useEffect(() => {
+        if (shouldValidationRefresh) {
+            refetch()
+            setValidationToRefresh(false)
+        }
+    }, [refetch, shouldValidationRefresh, setValidationToRefresh])
+
     const queryKey = useDataValueSetQueryKey()
     const activeMutations = useIsMutating({
         mutationKey: queryKey,
@@ -67,9 +82,9 @@ export default function ValidationResultsSidebar({ hide }) {
                 {dataChangedSinceValidation && (
                     <div className={styles.dataChangedNotice}>
                         <NoticeBox title="Data has changed since validation was run">
-                            Data in the entry form has changed, so validation
-                            output might be incorrect. Run validation again to
-                            check the current data.
+                            {i18n.t(
+                                'Data in the entry form has changed, so validation output might be incorrect. Run validation again to check the current data.'
+                            )}
                         </NoticeBox>
                     </div>
                 )}

--- a/src/shared/stores/index.js
+++ b/src/shared/stores/index.js
@@ -1,3 +1,4 @@
 export { useValueStore } from './data-value-store.js'
+export { useValidationStore } from './validation-store.js'
 export { useEntryFormStore } from './entry-form-store.js'
 export { useUnsavedDataStore } from './unsaved-data-store.js'

--- a/src/shared/stores/validation-store.js
+++ b/src/shared/stores/validation-store.js
@@ -1,0 +1,12 @@
+import create from 'zustand'
+
+const inititalState = {
+    validationToRefresh: false,
+}
+
+export const useValidationStore = create((set, get) => ({
+    ...inititalState,
+    setValidationToRefresh: (validationToRefresh) =>
+        set({ validationToRefresh }),
+    getValidationToRefresh: () => get().validationToRefresh,
+}))


### PR DESCRIPTION
re-run validation when the Run Validation is clicked while the validation sidebar is already open

### Notes
- I used `zustand` store to manage the flag to re-run the validation. The first implementation using the RightHandPanel context got the whole table to re-render unnecessarily. Using `zustand` felt like a much cleaner and succinct pattern than separating the setter and getter of the context, or adding yet another context.
- I implemented a specific store for managing this state, which might feel like an overkill, but it didn't belong logically to one of the other stores.
- this PR should unblock https://github.com/dhis2/aggregate-data-entry-app/pull/178

### Screenshot / recording
https://user-images.githubusercontent.com/1014725/192591556-5e867aec-dee3-4c5e-ace6-6bd244fb7cd7.mov

