### PR TITLE
feat: respect F_DATAVALUE_ADD user authority

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-30T08:51:43.336Z\n"
-"PO-Revision-Date: 2022-09-30T08:51:43.336Z\n"
+"POT-Creation-Date: 2022-09-30T09:14:01.095Z\n"
+"PO-Revision-Date: 2022-09-30T09:14:01.095Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -47,6 +47,12 @@ msgstr "Hide details"
 
 msgid "View details"
 msgstr "View details"
+
+msgid "Validation is not available offline"
+msgstr "Validation is not available offline"
+
+msgid "Validation is not available while changes are pending"
+msgstr "Validation is not available while changes are pending"
 
 msgid "Run validation"
 msgstr "Run validation"
@@ -286,6 +292,9 @@ msgstr "Fetching data set info"
 
 msgid "Error occurred while loading data set info"
 msgstr "Error occurred while loading data set info"
+
+msgid "Custom forms couldn't be made available offline. {{error}}"
+msgstr "Custom forms couldn't be made available offline. {{error}}"
 
 msgid "Value"
 msgstr "Value"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-26T16:14:30.586Z\n"
-"PO-Revision-Date: 2022-09-26T16:14:30.586Z\n"
+"POT-Creation-Date: 2022-09-30T08:51:43.336Z\n"
+"PO-Revision-Date: 2022-09-30T08:51:43.336Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -20,6 +20,9 @@ msgstr ""
 
 msgid "There was a problem loading metadata"
 msgstr "There was a problem loading metadata"
+
+msgid "The metadata response is invalid"
+msgstr "The metadata response is invalid"
 
 msgid "There is {{pendingMutations}} pending change."
 msgstr "There is {{pendingMutations}} pending change."
@@ -95,6 +98,13 @@ msgstr "{{length}} {{level}} priority alerts"
 
 msgid "Validation"
 msgstr "Validation"
+
+msgid ""
+"Data in the entry form has changed, so validation output might be "
+"incorrect. Run validation again to check the current data."
+msgstr ""
+"Data in the entry form has changed, so validation output might be "
+"incorrect. Run validation again to check the current data."
 
 msgid "Run validation again"
 msgstr "Run validation again"
@@ -304,6 +314,9 @@ msgstr "Mark for follow-up"
 msgid "Empty values can't be marked for follow -up"
 msgstr "Empty values can't be marked for follow -up"
 
+msgid "You do not have the authority to mark this value for follow -up"
+msgstr "You do not have the authority to mark this value for follow -up"
+
 msgid "Description: {{- description}}"
 msgstr "Description: {{- description}}"
 
@@ -325,8 +338,8 @@ msgstr "Marked for follow-up"
 msgid "Comment"
 msgstr "Comment"
 
-msgid "There was a problem loading the comment for this data item"
-msgstr "There was a problem loading the comment for this data item"
+msgid "There was a problem updating the comment for this data item"
+msgstr "There was a problem updating the comment for this data item"
 
 msgid "Choose an option"
 msgstr "Choose an option"
@@ -340,14 +353,17 @@ msgstr "Save comment"
 msgid "Cancel"
 msgstr "Cancel"
 
-msgid "No comment for this data item."
-msgstr "No comment for this data item."
-
 msgid "Edit comment"
 msgstr "Edit comment"
 
 msgid "Add comment"
 msgstr "Add comment"
+
+msgid "No comment for this data item."
+msgstr "No comment for this data item."
+
+msgid "You do not have the authority to add or edit comments"
+msgstr "You do not have the authority to add or edit comments"
 
 msgid "Details"
 msgstr "Details"
@@ -367,8 +383,14 @@ msgstr "Average value: {{avg}}"
 msgid "Delete limits"
 msgstr "Delete limits"
 
+msgid "You do not have the authority to delete limits"
+msgstr "You do not have the authority to delete limits"
+
 msgid "Edit limits"
 msgstr "Edit limits"
+
+msgid "You do not have the authority to add limits"
+msgstr "You do not have the authority to add limits"
 
 msgid "Min"
 msgstr "Min"
@@ -415,6 +437,9 @@ msgstr "Data cannot be added or changed because data entry has concluded."
 
 msgid "Data cannot be added or changed because data has been approved."
 msgstr "Data cannot be added or changed because data has been approved."
+
+msgid "You do not have the authority to edit entry forms"
+msgstr "You do not have the authority to edit entry forms"
 
 msgid "Data set locked"
 msgstr "Data set locked"

--- a/src/app/load-app.js
+++ b/src/app/load-app.js
@@ -32,14 +32,16 @@ const LoadApp = ({ children }) => {
         )
     }
 
-    if (!metadata.data) {
+    if (userInfo.isError) {
         return (
             <NoticeBox
                 error
                 className={css.noticeBoxWrapper}
-                title={i18n.t('There was a problem loading metadata')}
+                title={i18n.t(
+                    "There was a problem loading the user's information"
+                )}
             >
-                {i18n.t('The metadata response is invalid')}
+                {userInfo.error}
             </NoticeBox>
         )
     }

--- a/src/app/load-app.js
+++ b/src/app/load-app.js
@@ -9,14 +9,10 @@ import css from './load-app.module.css'
 const LoadApp = ({ children }) => {
     useCustomFormsPrefetch()
 
-    const { isLoading, isError, data, error } = useMetadata()
-    const {
-        isLoading: userLoading,
-        isError: userIsError,
-        data: userData,
-    } = useUserInfo()
+    const metadata = useMetadata()
+    const userInfo = useUserInfo()
 
-    if (isLoading || userLoading) {
+    if (metadata.isLoading || userInfo.isLoading) {
         return (
             <CenteredContent className={css.center} position={'top'}>
                 <CircularLoader />
@@ -24,22 +20,31 @@ const LoadApp = ({ children }) => {
         )
     }
 
-    if (isError) {
-        console.error(data)
+    if (metadata.isError) {
         return (
             <NoticeBox
-                className={css.noticeBoxWrapper}
                 error
+                className={css.noticeBoxWrapper}
                 title={i18n.t('There was a problem loading metadata')}
             >
-                {error?.message}
+                {metadata.error}
             </NoticeBox>
         )
     }
 
-    if (data && (userData || userIsError)) {
-        return children
+    if (!metadata.data) {
+        return (
+            <NoticeBox
+                error
+                className={css.noticeBoxWrapper}
+                title={i18n.t('There was a problem loading metadata')}
+            >
+                {i18n.t('The metadata response is invalid')}
+            </NoticeBox>
+        )
     }
+
+    return children
 }
 
 LoadApp.propTypes = {

--- a/src/data-workspace/data-details-sidebar/basic-information-follow-up-button.js
+++ b/src/data-workspace/data-details-sidebar/basic-information-follow-up-button.js
@@ -4,10 +4,12 @@ import React from 'react'
 import {
     useHighlightedField,
     useSetDataValueMutation,
+    useCanUserEditFields,
 } from '../../shared/index.js'
 import ItemPropType from './item-prop-type.js'
 
 const FollowUpButton = ({ item }) => {
+    const canUserEditFields = useCanUserEditFields()
     const { value } = useHighlightedField()
     const isEmptyField = !value
 
@@ -31,12 +33,13 @@ const FollowUpButton = ({ item }) => {
         )
     }
 
+    const disabled = isEmptyField || !canUserEditFields
     const markForFollowUpButton = (
         <Button
             secondary
             icon={<IconFlag24 color={colors.grey600} />}
             onClick={onMarkForFollowUp}
-            disabled={isEmptyField}
+            disabled={disabled}
         >
             {i18n.t('Mark for follow-up')}
         </Button>
@@ -56,8 +59,21 @@ const FollowUpButton = ({ item }) => {
         )
     }
 
+    if (!canUserEditFields) {
+        return (
+            <Tooltip
+                content={i18n.t(
+                    'You do not have the authority to mark this value for follow -up'
+                )}
+            >
+                {markForFollowUpButton}
+            </Tooltip>
+        )
+    }
+
     return <>{markForFollowUpButton}</>
 }
+
 FollowUpButton.propTypes = {
     item: ItemPropType.isRequired,
 }

--- a/src/data-workspace/data-details-sidebar/comment.js
+++ b/src/data-workspace/data-details-sidebar/comment.js
@@ -5,6 +5,7 @@ import {
     SingleSelect,
     SingleSelectOption,
     TextAreaFieldFF,
+    Tooltip,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
@@ -12,11 +13,12 @@ import { Form, useField } from 'react-final-form'
 import {
     ExpandableUnit,
     selectors,
-    useUnsavedDataStore,
+    useCanUserEditFields,
+    useContextSelectionId,
     useLockedContext,
     useMetadata,
     useSetDataValueMutation,
-    useContextSelectionId,
+    useUnsavedDataStore,
 } from '../../shared/index.js'
 import { getCellId } from '../../shared/stores/unsaved-data-store.js'
 import styles from './comment.module.css'
@@ -204,6 +206,7 @@ CommentEditForm.propTypes = {
 }
 
 export default function Comment({ item }) {
+    const canUserEditFields = useCanUserEditFields()
     const { locked } = useLockedContext()
     const [open, setOpen] = useState(true)
     const [editing, setEditing] = useState(false)
@@ -236,6 +239,17 @@ export default function Comment({ item }) {
         )
     }
 
+    const addEditButton = (
+        <Button
+            small
+            secondary
+            onClick={() => setEditing(true)}
+            disabled={!canUserEditFields || locked}
+        >
+            {item.comment ? i18n.t('Edit comment') : i18n.t('Add comment')}
+        </Button>
+    )
+
     return (
         <ExpandableUnit title={title} open={open} onToggle={setOpen}>
             {item.comment && (
@@ -258,14 +272,17 @@ export default function Comment({ item }) {
                 </p>
             )}
 
-            <Button
-                small
-                secondary
-                onClick={() => setEditing(true)}
-                disabled={locked}
-            >
-                {item.comment ? i18n.t('Edit comment') : i18n.t('Add comment')}
-            </Button>
+            {!canUserEditFields && (
+                <Tooltip
+                    content={i18n.t(
+                        'You do not have the authority to add or edit comments'
+                    )}
+                >
+                    {addEditButton}
+                </Tooltip>
+            )}
+
+            {canUserEditFields && addEditButton}
         </ExpandableUnit>
     )
 }

--- a/src/data-workspace/data-details-sidebar/limits-delete-button.js
+++ b/src/data-workspace/data-details-sidebar/limits-delete-button.js
@@ -2,7 +2,11 @@ import i18n from '@dhis2/d2-i18n'
 import { Button, Tooltip } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useOrgUnitId, useConnectionStatus } from '../../shared/index.js'
+import {
+    useOrgUnitId,
+    useConnectionStatus,
+    useCanUserEditFields,
+} from '../../shared/index.js'
 import { useDeleteLimits } from '../min-max-limits-mutations/index.js'
 
 const label = i18n.t('Delete limits')
@@ -12,9 +16,24 @@ export default function LimitsDeleteButton({
     categoryOptionComboId,
     disabled,
 }) {
+    const canEditFields = useCanUserEditFields()
     const { offline } = useConnectionStatus()
     const [orgUnitId] = useOrgUnitId()
     const deleteLimit = useDeleteLimits()
+
+    if (!canEditFields) {
+        return (
+            <Tooltip
+                content={i18n.t(
+                    'You do not have the authority to delete limits'
+                )}
+            >
+                <Button small secondary disabled>
+                    {label}
+                </Button>
+            </Tooltip>
+        )
+    }
 
     if (offline) {
         return (

--- a/src/data-workspace/data-details-sidebar/limits-display.js
+++ b/src/data-workspace/data-details-sidebar/limits-display.js
@@ -3,7 +3,10 @@ import { Button, ButtonStrip, Tooltip } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useConnectionStatus } from '../../shared/index.js'
+import {
+    useConnectionStatus,
+    useCanUserEditFields,
+} from '../../shared/index.js'
 import calculateAverage from './calculate-average.js'
 import LimitsAverageValueInfo from './limits-average-value-info.js'
 import LimitsDeleteButton from './limits-delete-button.js'
@@ -12,7 +15,20 @@ import styles from './limits.module.css'
 const editButtonLabel = i18n.t('Edit limits')
 
 function EditButton({ onClick }) {
+    const canEditFields = useCanUserEditFields()
     const { offline } = useConnectionStatus()
+
+    if (!canEditFields) {
+        return (
+            <Tooltip
+                content={i18n.t('You do not have the authority to add limits')}
+            >
+                <Button small primary disabled>
+                    {editButtonLabel}
+                </Button>
+            </Tooltip>
+        )
+    }
 
     if (offline) {
         return (
@@ -79,6 +95,7 @@ export default function LimitsDisplay({
                     </div>
                 )}
             </div>
+
             <ButtonStrip>
                 {canAdd && <EditButton onClick={onEditClick} />}
                 {canDelete && (

--- a/src/data-workspace/data-details-sidebar/limits.test.js
+++ b/src/data-workspace/data-details-sidebar/limits.test.js
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { useUserInfo } from '../../shared/use-user-info/use-user-info.js'
+import { useUserInfo, useCanUserEditFields } from '../../shared/index.js'
 import { render } from '../../test-utils/index.js'
 import { useMinMaxLimits } from '../use-min-max-limits.js'
 import Limits from './limits.js'
@@ -12,6 +12,11 @@ jest.mock('../use-min-max-limits.js', () => ({
 
 jest.mock('../../shared/use-user-info/use-user-info.js', () => ({
     useUserInfo: jest.fn(),
+}))
+
+jest.mock('../../shared/use-user-info/use-can-user-edit-fields.js', () => ({
+    __esModule: true,
+    default: jest.fn(() => true),
 }))
 
 describe('<Limits />', () => {
@@ -67,34 +72,6 @@ describe('<Limits />', () => {
             expect(
                 getByRole('button', { name: 'Delete limits' })
             ).toBeInTheDocument()
-        })
-    })
-
-    describe('when user does not have authority to add min/max', () => {
-        beforeAll(() => {
-            useMinMaxLimits.mockReturnValue({ min: 3, max: 4 })
-            useUserInfo.mockImplementation(() => ({
-                data: {
-                    authorities: [],
-                },
-            }))
-        })
-
-        it('does not show edit button', () => {
-            const { queryByRole } = render(
-                <Limits
-                    dataValue={{
-                        canHaveLimits: true,
-                        categoryOptionCombo: 'cat-combo-id',
-                        dataElement: 'de-id',
-                        valueType: 'INTEGER',
-                    }}
-                />
-            )
-
-            expect(
-                queryByRole('button', { name: 'Edit limits' })
-            ).not.toBeInTheDocument()
         })
     })
 
@@ -163,6 +140,7 @@ describe('<Limits />', () => {
                 },
             }))
         })
+
         afterEach(jest.clearAllMocks)
 
         it('renders the item limits', async () => {
@@ -210,6 +188,118 @@ describe('<Limits />', () => {
             userEvent.click(getByRole('button', { name: 'Cancel' }))
             expect(queryByLabelText('Min')).toBeNull()
             expect(getByTestId('limits-display')).toHaveTextContent('Min0Max10')
+        })
+    })
+
+    describe('when user does not have authority to add min/max', () => {
+        afterEach(jest.clearAllMocks)
+
+        it('does not show add button when the user does not have the "add minmax" authority', () => {
+            useMinMaxLimits.mockReturnValue({})
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: [
+                        'F_MINMAX_DATAELEMENT_DELETE',
+                        'F_DATAVALUE_ADD',
+                    ],
+                },
+            }))
+
+            const { queryByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            const addButton = queryByRole('button', { name: 'Add limits' })
+            expect(addButton).not.toBeInTheDocument()
+        })
+
+        it('does not show edit button when the user does not have the "add minmax" authority', () => {
+            useMinMaxLimits.mockReturnValue({ min: 3, max: 4 })
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: [
+                        'F_MINMAX_DATAELEMENT_DELETE',
+                        'F_DATAVALUE_ADD',
+                    ],
+                },
+            }))
+
+            const { queryByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            const editButton = queryByRole('button', { name: 'Edit limits' })
+            expect(editButton).not.toBeInTheDocument()
+        })
+
+        it('does not allow the user to add limits when user cannot add data values', () => {
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: [
+                        'F_MINMAX_DATAELEMENT_DELETE',
+                        'F_MINMAX_DATAELEMENT_ADD',
+                    ],
+                },
+            }))
+
+            useMinMaxLimits.mockReturnValue({})
+            useCanUserEditFields.mockImplementation(() => false)
+
+            const { queryByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            const addButton = queryByRole('button', { name: 'Add limits' })
+            expect(addButton).toHaveAttribute('disabled')
+        })
+
+        it('does not allow the user to edit limits when user cannot add data values', () => {
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: [
+                        'F_MINMAX_DATAELEMENT_DELETE',
+                        'F_MINMAX_DATAELEMENT_ADD',
+                    ],
+                },
+            }))
+
+            useMinMaxLimits.mockReturnValue({ min: 3, max: 4 })
+            useCanUserEditFields.mockImplementation(() => false)
+
+            const { queryByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            const editButton = queryByRole('button', { name: 'Edit limits' })
+            expect(editButton).toHaveAttribute('disabled')
         })
     })
 })

--- a/src/data-workspace/data-details-sidebar/no-limits.js
+++ b/src/data-workspace/data-details-sidebar/no-limits.js
@@ -2,14 +2,30 @@ import i18n from '@dhis2/d2-i18n'
 import { Button, Tooltip } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useConnectionStatus } from '../../shared/index.js'
+import {
+    useConnectionStatus,
+    useCanUserEditFields,
+} from '../../shared/index.js'
 import sharedStyles from './limits.module.css'
 import noLimitsStyles from './no-limits.module.css'
 
 const buttonLabel = i18n.t('Add limits')
 
 function AddButton({ onAddLimitsClick }) {
+    const canEditFields = useCanUserEditFields()
     const { offline } = useConnectionStatus()
+
+    if (!canEditFields) {
+        return (
+            <Tooltip
+                content={i18n.t('You do not have the authority to add limits')}
+            >
+                <Button small disabled className={noLimitsStyles.addButton}>
+                    {buttonLabel}
+                </Button>
+            </Tooltip>
+        )
+    }
 
     if (offline) {
         return (

--- a/src/data-workspace/entry-form.js
+++ b/src/data-workspace/entry-form.js
@@ -24,6 +24,9 @@ const lockedNoticeBoxMessages = {
     [LockedStates.LOCKED_APPROVED]: i18n.t(
         'Data cannot be added or changed because data has been approved.'
     ),
+    [LockedStates.LOCKED_NO_AUTHORITY]: i18n.t(
+        'You do not have the authority to edit entry forms'
+    ),
 }
 
 const formTypeToComponent = {

--- a/src/shared/locked-status/locked-info-provider.js
+++ b/src/shared/locked-status/locked-info-provider.js
@@ -1,14 +1,20 @@
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
+import { useCanUserEditFields } from '../use-user-info/index.js'
 import { LockedContext } from './locked-info-context.js'
 import { LockedStates } from './locked-states.js'
 
 export function LockedProvider({ children }) {
+    const userCanEditFields = useCanUserEditFields()
     const [lockStatus, setLockStatus] = useState(LockedStates.OPEN)
 
     const value = {
-        lockStatus,
-        locked: lockStatus !== LockedStates.OPEN,
+        // We treat fields that can't be edited for
+        // authority reasons as locked fields
+        locked: lockStatus !== LockedStates.OPEN || !userCanEditFields,
+        lockStatus: !userCanEditFields
+            ? LockedStates.LOCKED_NO_AUTHORITY
+            : lockStatus,
         setLockStatus,
     }
 

--- a/src/shared/locked-status/locked-states.js
+++ b/src/shared/locked-status/locked-states.js
@@ -3,6 +3,7 @@ export const LockedStates = Object.freeze({
     LOCKED_DATA_INPUT_PERIOD: 'Locked_data_input_period',
     LOCKED_EXPIRY_DAYS: 'Locked_expiry_days',
     LOCKED_APPROVED: 'Locked_approved',
+    LOCKED_NO_AUTHORITY: 'Locked_no_authority',
 })
 
 export const BackendLockStatusMap = Object.freeze({

--- a/src/shared/use-current-date-string-at-server-timezone/use-current-date-string-at-server-timezone.js
+++ b/src/shared/use-current-date-string-at-server-timezone/use-current-date-string-at-server-timezone.js
@@ -2,7 +2,6 @@ import { useConfig } from '@dhis2/app-runtime'
 import { getCurrentDate } from '../fixed-periods/index.js'
 
 const getLocalDateString = (date) => {
-    console.log(date, typeof date, date instanceof Date)
     const yyyy = date.getFullYear()
     const mm = String(date.getMonth() + 1).padStart(2, '0')
     const dd = String(date.getDate()).padStart(2, '0')

--- a/src/shared/use-user-info/index.js
+++ b/src/shared/use-user-info/index.js
@@ -1,2 +1,3 @@
 export { useUserInfo } from './use-user-info.js'
+export { default as useCanUserEditFields } from './use-can-user-edit-fields.js'
 export * as userInfoSelectors from './user-info-selectors.js'

--- a/src/shared/use-user-info/use-can-user-edit-fields.js
+++ b/src/shared/use-user-info/use-can-user-edit-fields.js
@@ -1,0 +1,6 @@
+import { useUserInfo, userInfoSelectors } from '../use-user-info/index.js'
+
+export default function useCanUserEditFields() {
+    const { data: userInfo } = useUserInfo()
+    return userInfoSelectors.getCanEditFields(userInfo)
+}

--- a/src/shared/use-user-info/user-info-selectors.js
+++ b/src/shared/use-user-info/user-info-selectors.js
@@ -1,13 +1,21 @@
 const ALL_AUTHORITY = 'ALL'
 const DELETE_MIN_MAX_AUTHORITY = 'F_MINMAX_DATAELEMENT_DELETE'
 const ADD_MIN_MAX_AUTHORITY = 'F_MINMAX_DATAELEMENT_ADD'
+const DATAVALUE_ADD = 'F_DATAVALUE_ADD'
 
 export const getAuthorities = (userInfo) => userInfo.authorities
+
 export const getCanDeleteMinMax = (userInfo) =>
     userInfo.authorities.some((auth) =>
         [DELETE_MIN_MAX_AUTHORITY, ALL_AUTHORITY].includes(auth)
     )
+
 export const getCanAddMinMax = (userInfo) =>
     userInfo.authorities.some((auth) =>
         [ADD_MIN_MAX_AUTHORITY, ALL_AUTHORITY].includes(auth)
     )
+
+export const getCanEditFields = (userInfo) =>
+    !!userInfo?.authorities?.some((auth) => {
+        return [DATAVALUE_ADD, ALL_AUTHORITY].includes(auth)
+    })


### PR DESCRIPTION
Closes TECH-1439 ([link](https://dhis2.atlassian.net/browse/TECH-1439))

* [x] Shows a "locked" info notice box when authorities are missing
* [x] Disabled inputs when authorities are missing
* [x] Disabled (un-)marking for followup when authorities are missing
* [x] Disabled adding/editing comments when authorities are missing
* [x] Disabled settings/deleting min- & max-limits when authorities are missing
* [x] Ensures that `<LoadApp />` always returns something (no implicit `undefined` return)
* [x] Removes `console.log` statement from `use-current-date-string-at-server-timezone.js`

NOTE: @HendrikThePendric commented on the tooltip issue. We've agreed to tackle that separately as it's already tracked in [TECH-1341](https://dhis2.atlassian.net/browse/TECH-1341) and it's not a new issue of this PR.