### PR TITLE
fix: print styles [TECH-1312]

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -14,7 +14,7 @@ body {
         display: none;
     }
 
-    .hide-for-print {
+    .hideForPrint {
         display: none !important;
     }
     

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -9,6 +9,7 @@ body {
     div {
         display: block !important; /* This is needed to get around issues with FireFox printing CSS grids: https://tosbourn.com/firefox-printing-issue-for-grid-css/ */
         max-width: 100% !important;
+        outline: none !important;
     }
     .app-shell-adapter > header  {
         display: none;
@@ -29,7 +30,7 @@ body {
     
     tr, td {
         break-inside: avoid;
-        page-break-inside: avoid;
+        page-break-inside: avoid;;
     }
 
     .form-cleared input,

--- a/src/context-selection/context-selection/context-selection.js
+++ b/src/context-selection/context-selection/context-selection.js
@@ -11,6 +11,7 @@ import { DataSetSelectorBarItem } from '../data-set-selector-bar-item/index.js'
 import { OrgUnitSetSelectorBarItem } from '../org-unit-selector-bar-item/index.js'
 import { PeriodSelectorBarItem } from '../period-selector-bar-item/index.js'
 import { SectionFilterSelectorBarItem } from '../section-filter-selector-bar-item/index.js'
+import styles from './context-selection.module.css'
 import RightHandSideContent from './right-hand-side-content.js'
 import useShouldHideClearButton from './use-should-hide-clear-button.js'
 
@@ -30,18 +31,20 @@ export default function ContextSelector({ setSelectionHasNoFormMessage }) {
     }
 
     return (
-        <SelectorBar
-            onClearSelectionClick={onClearSelectionClick}
-            additionalContent={<RightHandSideContent />}
-        >
-            <DataSetSelectorBarItem />
-            <OrgUnitSetSelectorBarItem />
-            <PeriodSelectorBarItem />
-            <AttributeOptionComboSelectorBarItem
-                setSelectionHasNoFormMessage={setSelectionHasNoFormMessage}
-            />
-            <SectionFilterSelectorBarItem />
-        </SelectorBar>
+        <div className={styles.hideForPrint}>
+            <SelectorBar
+                onClearSelectionClick={onClearSelectionClick}
+                additionalContent={<RightHandSideContent />}
+            >
+                <DataSetSelectorBarItem />
+                <OrgUnitSetSelectorBarItem />
+                <PeriodSelectorBarItem />
+                <AttributeOptionComboSelectorBarItem
+                    setSelectionHasNoFormMessage={setSelectionHasNoFormMessage}
+                />
+                <SectionFilterSelectorBarItem />
+            </SelectorBar>
+        </div>
     )
 }
 

--- a/src/context-selection/context-selection/context-selection.module.css
+++ b/src/context-selection/context-selection/context-selection.module.css
@@ -1,0 +1,5 @@
+@media print {
+    .hideForPrint {
+        composes: hideForPrint from '../../app/app.css'
+    }   
+}

--- a/src/context-selection/context-selection/right-hand-side-content.js
+++ b/src/context-selection/context-selection/right-hand-side-content.js
@@ -1,12 +1,10 @@
-import classNames from 'classnames'
 import React from 'react'
 import { OptionsButton } from '../options/index.js'
 import styles from './right-hand-side-content.module.css'
 
 export default function RightHandSideContent() {
-    const containerStyles = classNames(styles.container, 'hide-for-print')
     return (
-        <div className={containerStyles}>
+        <div className={styles.container}>
             <OptionsButton />
         </div>
     )

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -20,7 +20,7 @@
     /* Make this a coordinate context for corner indicators */
     position: relative;
 }
-.cellInnerWrapper:hover:not(.disabled) {
+.cellInnerWrapper:hover:not(.disabled):not(.highlighted) {
     outline: 1px solid #a0adba;
 }
 
@@ -29,8 +29,8 @@
 }
 
 .highlighted {
-    outline: 3px solid var(--colors-grey800) !important;
-    border: none !important;
+    outline: 3px solid var(--colors-grey800);
+    border: none;
     /* Fix to prevent bottom outline to be clipped by next cell */
     z-index: 1;
 }
@@ -38,7 +38,7 @@
 
 .highlighted.active {
     outline-color: var(--theme-focus) !important;
-}
+}t
 
 .disabled {
     background-color: var(--colors-grey200);

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -104,3 +104,9 @@
     color: var(--colors-grey700) !important;
     cursor: not-allowed;
 }
+
+@media print {
+    .hideForPrint {
+        composes: hideForPrint from '../../app/app.css'
+    }
+}

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -15,7 +15,7 @@ import styles from './data-entry-cell.module.css'
 /** Three dots or triangle in top-right corner of cell */
 const SyncStatusIndicator = ({ isLoading, isSynced }) => {
     return (
-        <div className={styles.topRightIndicator}>
+        <div className={cx(styles.topRightIndicator, styles.hideForPrint)}>
             {isLoading ? (
                 <IconMore16 color={colors.grey700} />
             ) : isSynced ? (
@@ -32,7 +32,7 @@ SyncStatusIndicator.propTypes = {
 /** Grey triangle in bottom left of cell */
 const CommentIndicator = ({ hasComment }) => {
     return (
-        <div className={styles.bottomRightIndicator}>
+        <div className={cx(styles.bottomRightIndicator, styles.hideForPrint)}>
             {hasComment && <div className={styles.bottomRightTriangle} />}
         </div>
     )

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -112,7 +112,7 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
 
     const dataSet = selectors.getDataSetById(metadata, dataSetId)
 
-    const footerClasses = classNames(styles.footer, 'hide-for-print')
+    const footerClasses = classNames(styles.footer, styles.hideForPrint)
     const dataValueSet = initialDataValuesFetch.data?.dataValues
 
     return (

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -31,3 +31,9 @@
 .formMessageBox {
     margin: var(--spacers-dp8) var(--spacers-dp12) var(--spacers-dp8) var(--spacers-dp12);
 }
+
+@media print {
+    .hideForPrint {
+        composes: hideForPrint from '../app/app.css'
+    }
+}

--- a/src/data-workspace/entry-form.module.css
+++ b/src/data-workspace/entry-form.module.css
@@ -14,3 +14,9 @@
 .filterField {
     width: 420px;
 }
+
+@media print {
+    .hideForPrint {
+        composes: hideForPrint from '../app/app.css'
+    }
+}

--- a/src/data-workspace/filter-field.js
+++ b/src/data-workspace/filter-field.js
@@ -9,7 +9,7 @@ import styles from './entry-form.module.css'
 
 export default function FilterField({ value, setFilterText, formType }) {
     const setHighlightedFieldId = useSetHighlightedFieldIdContext()
-    const wrapperClasses = classNames(styles.filterWrapper, 'hide-for-print')
+    const wrapperClasses = classNames(styles.filterWrapper, styles.hideForPrint)
     return (
         <div className={wrapperClasses}>
             <InputField

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -62,7 +62,7 @@ export function SectionFormSection({ section, dataSetId, globalFilterText }) {
     )
 
     const filterInputId = `filter-input-${section.id}`
-    const headerCellStyles = classNames(styles.headerCell, 'hide-for-print')
+    const headerCellStyles = classNames(styles.headerCell, styles.hideForPrint)
 
     return (
         <Table className={styles.table} suppressZebraStriping>

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -66,3 +66,9 @@
 .sectionTab {
     margin-bottom: 8px;
 }
+
+@media print {
+    .hideForPrint {
+        composes: hideForPrint from '../../app/app.css'
+    }
+}

--- a/src/right-hand-panel/right-hand-panel.js
+++ b/src/right-hand-panel/right-hand-panel.js
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './right-hand-panel.module.css'
@@ -19,7 +20,7 @@ export default function RightHandPanel({ idSidebarMap }) {
     }
 
     return (
-        <div className={styles.wrapper}>
+        <div className={cx(styles.wrapper, styles.hideForPrint)}>
             <SidebarComponent show={show} hide={hide} />
         </div>
     )

--- a/src/right-hand-panel/right-hand-panel.module.css
+++ b/src/right-hand-panel/right-hand-panel.module.css
@@ -9,3 +9,9 @@
     overflow: hidden;
     overflow-y: auto;
 }
+
+@media print {
+    .hideForPrint {
+        composes: hideForPrint from '../app/app.css'
+    }
+}


### PR DESCRIPTION
This PR fixes print styling to:

- remove interface elements other than dataworkspace area
- disable printing of status/comment indicators
- disable printing of outlines (for invalid and highlighted cells)

_screen_
<img width="500" alt="image" src="https://user-images.githubusercontent.com/18490902/196170847-a00b5cdb-b161-4711-88bf-ff905510f71e.png">

### print format before (development branch)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/18490902/196171967-504a5bac-ea95-4d6e-8b21-e9665edb6ede.png">

### print format after this PR
<img width="500" alt="image" src="https://user-images.githubusercontent.com/18490902/196170990-72b958d3-3090-4f85-ab23-b59a34fe4c84.png">




