### PR TITLE
fix: fix design issues from testing

### DIFF
--- a/src/bottom-bar/complete-button.js
+++ b/src/bottom-bar/complete-button.js
@@ -57,7 +57,7 @@ export default function CompleteButton({ disabled }) {
 
     return (
         <>
-            <Button disabled={disabled} onClick={onClick}>
+            <Button small disabled={disabled} onClick={onClick}>
                 {label}
             </Button>
         </>

--- a/src/bottom-bar/main-tool-bar.js
+++ b/src/bottom-bar/main-tool-bar.js
@@ -79,6 +79,7 @@ export default function MainToolBar() {
                 offline={offline}
             >
                 <Button
+                    small
                     disabled={validateDisabled}
                     className={styles.toolbarItem}
                     onClick={validate}

--- a/src/context-selection/contextual-help-sidebar/shortcuts.js
+++ b/src/context-selection/contextual-help-sidebar/shortcuts.js
@@ -10,9 +10,16 @@ const Action = ({ label, shortcuts }) => (
         <div>{label}</div>
         <div className={styles.shortcutKeys}>
             {shortcuts.map((shortcut, index) => (
-                <span key={index} className={styles.shortcutKey}>
-                    {shortcut}
-                </span>
+                <>
+                    <span key={index} className={styles.shortcutKey}>
+                        {shortcut}
+                    </span>
+                    {index !== shortcuts.length - 1 && (
+                        <span className={styles.shortcutOr}>{` ${i18n.t(
+                            'or'
+                        )} `}</span>
+                    )}
+                </>
             ))}
         </div>
     </div>

--- a/src/context-selection/contextual-help-sidebar/shortcuts.module.css
+++ b/src/context-selection/contextual-help-sidebar/shortcuts.module.css
@@ -15,9 +15,16 @@
     color: var(--colors-grey900);
 }
 
+.shortcutOr {
+    font-size: 13px;
+    line-height: 16px;
+    color: var(--colors-grey900);
+    padding: 4px 0 4px 0;
+}
+
 .shortcutKeys {
     display: inline-flex;
-    gap: var(--spacers-dp16);
+    gap: var(--spacers-dp8);
 }
 
 .shortcutKey {

--- a/src/data-workspace/data-details-sidebar/no-limits.js
+++ b/src/data-workspace/data-details-sidebar/no-limits.js
@@ -6,7 +6,6 @@ import {
     useConnectionStatus,
     useCanUserEditFields,
 } from '../../shared/index.js'
-import sharedStyles from './limits.module.css'
 import noLimitsStyles from './no-limits.module.css'
 
 const buttonLabel = i18n.t('Add limits')
@@ -20,7 +19,7 @@ function AddButton({ onAddLimitsClick }) {
             <Tooltip
                 content={i18n.t('You do not have the authority to add limits')}
             >
-                <Button small disabled className={noLimitsStyles.addButton}>
+                <Button small secondary disabled>
                     {buttonLabel}
                 </Button>
             </Tooltip>
@@ -30,7 +29,7 @@ function AddButton({ onAddLimitsClick }) {
     if (offline) {
         return (
             <Tooltip content={i18n.t('Not available offline')}>
-                <Button small disabled className={noLimitsStyles.addButton}>
+                <Button small secondary disabled>
                     {buttonLabel}
                 </Button>
             </Tooltip>
@@ -38,7 +37,7 @@ function AddButton({ onAddLimitsClick }) {
     }
 
     return (
-        <Button small onClick={onAddLimitsClick}>
+        <Button small secondary onClick={onAddLimitsClick}>
             {buttonLabel}
         </Button>
     )
@@ -50,12 +49,12 @@ AddButton.propTypes = {
 
 export default function NoLimits({ onAddLimitsClick, canAdd }) {
     return (
-        <div className={sharedStyles.limit}>
+        <>
             <p className={noLimitsStyles.label}>
                 {i18n.t('No limits set for this data item.')}
             </p>
             {canAdd && <AddButton onAddLimitsClick={onAddLimitsClick} />}
-        </div>
+        </>
     )
 }
 

--- a/src/data-workspace/data-details-sidebar/no-limits.module.css
+++ b/src/data-workspace/data-details-sidebar/no-limits.module.css
@@ -1,8 +1,3 @@
-/* ":global(..)" necessary due to specificify of @dhis2/ui */
-:global(button).addButton {
-    display: block;
-}
-
 .label {
     color: var(--colors-grey600);
     font-size: 14px;

--- a/src/data-workspace/data-entry-cell/validation-tooltip.js
+++ b/src/data-workspace/data-entry-cell/validation-tooltip.js
@@ -25,7 +25,10 @@ const TooltipManager = React.forwardRef(function TooltipManager(
         else {
             close()
         }
-    }, [invalid, active, open, close])
+        // onMouseOut, onMouseOver are not stable references
+        // when included, useEffect refires and causes tooltip to flicker
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [invalid, active])
 
     // Only open the tooltip if the cell is invalid
     const handleMouseOver = () => {


### PR DESCRIPTION
## Add or between items in shortcut menu [DHIS2-13955](https://dhis2.atlassian.net/browse/DHIS2-13955)

_before_
<img width="300" alt="image" src="https://user-images.githubusercontent.com/18490902/196414575-7f65eb68-6c36-4da6-8087-d43197a58595.png">


_after_
<img width="300" alt="image" src="https://user-images.githubusercontent.com/18490902/196414429-00fb7de9-2f7e-4c5a-895d-32f723d2ea5e.png">


## make bottom bar buttons small [DHIS2-13956](https://dhis2.atlassian.net/browse/DHIS2-13956)

_before_
<img width="269" alt="image" src="https://user-images.githubusercontent.com/18490902/196414659-858227e6-4715-4bb8-b148-b6c9a8e74d0c.png">

_after_
<img width="282" alt="image" src="https://user-images.githubusercontent.com/18490902/196414704-8119d58e-ab37-4cc4-ac0f-91a7486f4e8d.png">


## update styling for Add limits button [DHIS2-13958](https://dhis2.atlassian.net/browse/DHIS2-13958)

_before_
<img width="334" alt="image" src="https://user-images.githubusercontent.com/18490902/196414764-84f3397c-8e3e-4154-a1d7-236a30b7dffd.png">

_after_
<img width="372" alt="image" src="https://user-images.githubusercontent.com/18490902/196414816-f6fadd2d-ac79-463f-a66a-9f61de6b245b.png">


## prevent validation tooltip flicker [DHIS2-13954](https://dhis2.atlassian.net/browse/DHIS2-13954)
I think @Birkbjo is including a fix for this in his PR for error handling, but I thought maybe it would be sensible to submit separately as well, so that there's a fix independent of those changes?

_before_
![validation_tooltip_before](https://user-images.githubusercontent.com/18490902/196415358-4b2fe47b-0b95-416e-acff-4ee17bcc7127.gif)


_after_
![validation_tooltip_after](https://user-images.githubusercontent.com/18490902/196415371-6edbc07b-b0f5-4de1-9ad6-dd7d56737949.gif)
