### PR TITLE
fix: make useDataValueParams and useApiAttributeParams stable

### DIFF
--- a/src/shared/data-value-mutations/use-data-value-params.js
+++ b/src/shared/data-value-mutations/use-data-value-params.js
@@ -1,6 +1,6 @@
+import { useMemo } from 'react'
 import { useApiAttributeParams } from '../use-api-attribute-params.js'
 import { useContextSelection } from '../use-context-selection/index.js'
-
 /**
  * Formats a de/coc pair and the current context selection for use with the
  * `api/dataValues` endpoint
@@ -9,24 +9,33 @@ export const useDataValueParams = ({ deId, cocId }) => {
     const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
     const { attributeCombo, attributeOptions } = useApiAttributeParams()
 
-    const dataValueParams = {
-        de: deId,
-        co: cocId,
-        ds: dataSetId,
-        ou: orgUnitId,
-        pe: periodId,
-    }
+    return useMemo(() => {
+        const dataValueParams = {
+            de: deId,
+            co: cocId,
+            ds: dataSetId,
+            ou: orgUnitId,
+            pe: periodId,
+        }
 
-    // Add attribute params to context params if attribute is not default
-    // (useApiAttributeParams helper returns undefined props if attribute
-    // is default)
-    if (attributeCombo) {
-        // Get a ';'-separated listed of attribute options
-        // (note these are sorted in useApiAttributeParams)
-        const attributeOptionIdList = attributeOptions.join(';')
-        dataValueParams.cc = attributeCombo
-        dataValueParams.cp = attributeOptionIdList
-    }
-
-    return dataValueParams
+        // Add attribute params to context params if attribute is not default
+        // (useApiAttributeParams helper returns undefined props if attribute
+        // is default)
+        if (attributeCombo) {
+            // Get a ';'-separated listed of attribute options
+            // (note these are sorted in useApiAttributeParams)
+            const attributeOptionIdList = attributeOptions.join(';')
+            dataValueParams.cc = attributeCombo
+            dataValueParams.cp = attributeOptionIdList
+        }
+        return dataValueParams
+    }, [
+        dataSetId,
+        orgUnitId,
+        periodId,
+        attributeCombo,
+        attributeOptions,
+        cocId,
+        deId,
+    ])
 }

--- a/src/shared/use-api-attribute-params.js
+++ b/src/shared/use-api-attribute-params.js
@@ -1,6 +1,6 @@
+import { useMemo } from 'react'
 import { useMetadata, selectors } from './metadata/index.js'
 import { useContextSelection } from './use-context-selection/index.js'
-
 /**
  * Finds the attributeComboId for the current attribute-option selection.
  * Returns { attributeCombo: undefined, attributeOptions: undefined }
@@ -11,30 +11,34 @@ export const useApiAttributeParams = () => {
     const { data } = useMetadata()
     const [{ dataSetId, attributeOptionComboSelection }] = useContextSelection()
 
-    if (data && dataSetId) {
-        const dataSet = selectors.getDataSetById(data, dataSetId)
-        if (dataSet === null || dataSet === undefined) {
-            return
-        }
-        const catComboId = dataSet.categoryCombo.id
-        const categoryCombo = selectors.getCategoryComboById(data, catComboId)
+    return useMemo(() => {
+        if (data && dataSetId) {
+            const dataSet = selectors.getDataSetById(data, dataSetId)
+            if (dataSet === null || dataSet === undefined) {
+                return
+            }
+            const catComboId = dataSet.categoryCombo.id
+            const categoryCombo = selectors.getCategoryComboById(
+                data,
+                catComboId
+            )
 
-        // Sort these to produce consistent query and mutation keys
-        const selectedOptions = Object.values(
-            attributeOptionComboSelection
-        ).sort()
+            // Sort these to produce consistent query and mutation keys
+            const selectedOptions = Object.values(
+                attributeOptionComboSelection
+            ).sort()
 
-        if (!categoryCombo.isDefault) {
-            // we don't need to supply attributeCombo/options when it's default
-            return {
-                attributeCombo: catComboId,
-                attributeOptions: selectedOptions,
+            if (!categoryCombo.isDefault) {
+                // we don't need to supply attributeCombo/options when it's default
+                return {
+                    attributeCombo: catComboId,
+                    attributeOptions: selectedOptions,
+                }
             }
         }
-    }
-
-    return {
-        attributeCombo: undefined,
-        attributeOptions: undefined,
-    }
+        return {
+            attributeCombo: undefined,
+            attributeOptions: undefined,
+        }
+    }, [data, dataSetId, attributeOptionComboSelection])
 }


### PR DESCRIPTION
These were not stable, and thus the result of these hooks were unfit for use in other hooks, as that would cause them to run on every-render.