### PR TITLE
fix: update variable name [TECH-1465]

### DIFF
--- a/src/shared/locked-status/use-check-lock-status.js
+++ b/src/shared/locked-status/use-check-lock-status.js
@@ -14,7 +14,7 @@ const isDataInputPeriodLocked = ({
     dataSetId,
     periodId,
     metadata,
-    adjustedCurrentDateString,
+    currentDayString,
 }) => {
     const dataInputPeriod = selectors.getApplicableDataInputPeriod(
         metadata,
@@ -26,7 +26,7 @@ const isDataInputPeriodLocked = ({
         return false
     }
 
-    const currentDateAtServerTimeZone = new Date(adjustedCurrentDateString)
+    const currentDateAtServerTimeZone = new Date(currentDayString)
     const openingDate = new Date(dataInputPeriod.openingDate)
     const closingDate = new Date(dataInputPeriod.closingDate)
 


### PR DESCRIPTION
fixes variable name to make sure data input periods trigger locking:

_after PR (with data input period added to Facility Assessment for 2019_:
<img width="793" alt="image" src="https://user-images.githubusercontent.com/18490902/197216178-148aa0ac-84d1-4a6c-942d-47624d746eeb.png">
