### PR TITLE
fix: ensure biweeks allow entry over entire year [TECH-1308]

### DIFF
--- a/src/shared/fixed-periods/fixed-periods.js
+++ b/src/shared/fixed-periods/fixed-periods.js
@@ -287,8 +287,9 @@ const getBiWeeklyPeriodType = (formatYyyyMmDd, fnFilter) => {
                 biWeekNumber,
             })} - ${period.startDate} - ${period.endDate}`
 
-            // if end date is Jan 4th or later, biweek belongs to next year
-            if (date.getFullYear() > year && date.getDate() >= 4) {
+            // if end date is Jan 11th or later, biweek belongs to next year
+            // Jan 11 is used because week 1 (Jan 4) may need to be included in previous year's biweeks
+            if (date.getFullYear() > year && date.getDate() >= 11) {
                 break
             }
 


### PR DESCRIPTION
Fixes [TECH-1308](https://dhis2.atlassian.net/browse/TECH-1308)

This change aligns with the [backend logic](https://github.com/dhis2/dhis2-core/blob/88792d8e726832ddff9f95dec8c0ff86bd777cf4/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.period.js#L1020) for calculating biweekly periods.

The issue we have previously is that we assumed that if the biweek period had an end date on/after 4 January (i.e. iso week 1), that the period would belong to the following period. However, sometimes we need to include a biweek including week 1 in order to ensure we include week 52.

So, because we are dealing with biweeks (rather than weeks), we need to extend this to 11 January (iso week 2) so that we are guaranteed to capture the full date range.

The update I made should be consistent with what the backend is doing (there's no javascript date equivalent for the java `weekOfYear` method as far as I know), but essentially both are saying to stop once we know the endDate is at beyond week2. The backend is also basing this logic off of startDate rather than endDate, but I did not further change our implementation, as doing so seemed unnecessary).

**Before**
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/18490902/200338764-c833b3ef-85de-4ad3-a843-b6b84a367f8b.png">

**After**
<img width="322" alt="image" src="https://user-images.githubusercontent.com/18490902/200338807-0e8d4730-2d4a-4d78-90d0-12470901fd87.png">

