### PR TITLE
ci(renovate): enable automerging minor updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,8 +5,7 @@
         ":automergePr",
         ":automergeRequireAllStatusChecks",
         ":enableVulnerabilityAlerts",
-        "npm:unpublishSafe",
-        "schedule:nonOfficeHours"
+        "npm:unpublishSafe"
     ],
     "major": {
         "dependencyDashboardApproval": true

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,13 @@
 {
     "extends": [
         "config:base",
-        ":dependencyDashboardApproval",
-        ":enableVulnerabilityAlerts"
-    ]
+        ":automergeMinor",
+        ":automergePr",
+        ":automergeRequireAllStatusChecks",
+        ":enableVulnerabilityAlerts",
+        "schedule:nonOfficeHours"
+    ],
+    "major": {
+        "dependencyDashboardApproval": true
+    }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,6 @@
     ],
     "major": {
         "dependencyDashboardApproval": true
-    }
+    },
+    "timezone": "Europe/Oslo"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
         ":automergePr",
         ":automergeRequireAllStatusChecks",
         ":enableVulnerabilityAlerts",
+        "npm:unpublishSafe",
         "schedule:nonOfficeHours"
     ],
     "major": {


### PR DESCRIPTION
This enables automerging minor (and patch) updates to our default branch (development). This will happen without any input from us, outside of oslo office hours. It will create a PR and require all status checks to pass before it merges.

Major updates still need to be triggered and merged manually by us.

- https://docs.renovatebot.com/key-concepts/automerge/
- https://docs.renovatebot.com/key-concepts/dashboard/#require-approval-for-major-updates
- https://docs.renovatebot.com/presets-default/#automergepr
- https://docs.renovatebot.com/presets-default/#automergeminor
- https://docs.renovatebot.com/presets-default/#automergerequireallstatuschecks
- https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours
- https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
- https://docs.renovatebot.com/configuration-options/#timezone

For this to respect all our CI checks we need to make sure that they're all required (unless it's safe to skip them).

We could do a couple other things to make this even less noisy: https://docs.renovatebot.com/noise-reduction. Like use branch instead of PR updates, or automerge all linter and test updates. But that requires a little more configuration so it seemed better to me to start simple.

We'll also need to add this bot: https://github.com/apps/renovate-approve, or drop our required review requirement. See: https://github.com/renovatebot/renovate/issues/2446.