### PR TITLE
ci(renovate): schedule updates outside of office hours

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
         ":automergePr",
         ":automergeRequireAllStatusChecks",
         ":enableVulnerabilityAlerts",
-        "npm:unpublishSafe"
+        "npm:unpublishSafe",
+        "schedule:nonOfficeHours"
     ],
     "major": {
         "dependencyDashboardApproval": true


### PR DESCRIPTION
The automerging seems to work well. Some manual intervention required at times, but it seems stable enough to enable this to run outside of office hours.