### PR TITLE
ci(renovate): use our shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,15 +1,3 @@
 {
-    "extends": [
-        "config:base",
-        ":automergeMinor",
-        ":automergePr",
-        ":automergeRequireAllStatusChecks",
-        ":enableVulnerabilityAlerts",
-        "npm:unpublishSafe",
-        "schedule:nonOfficeHours"
-    ],
-    "major": {
-        "dependencyDashboardApproval": true
-    },
-    "timezone": "Europe/Oslo"
+    "extends": ["github>dhis2/renovate-config"]
 }


### PR DESCRIPTION
Move to our shared renovate config. Hosted here: https://github.com/dhis2/renovate-config