### PR TITLE
fix: adjust disabled org unit style

### DIFF
--- a/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.js
+++ b/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.js
@@ -1,6 +1,6 @@
 import { useAlert } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { SelectorBarItem, IconBlock16, Divider } from '@dhis2/ui'
+import { SelectorBarItem, Divider, Tooltip } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import {
@@ -27,8 +27,13 @@ import useUserOrgUnits from './use-user-org-units.js'
 const UnclickableLabel = ({ label }) => {
     return (
         <div className={css.disabled}>
-            <IconBlock16 />
-            <span>{label}</span>
+            <Tooltip
+                content={i18n.t(
+                    'Dataset is not assigned to this organisation unit'
+                )}
+            >
+                <span>{label}</span>
+            </Tooltip>
         </div>
     )
 }
@@ -108,7 +113,9 @@ export default function OrganisationUnitSetSelectorBarItem() {
                                 onChange={setFilter}
                             />
                         </div>
-
+                        <div className={css.dividerContainer}>
+                            <Divider dense />
+                        </div>
                         <div className={css.orgUnitTreeContainer}>
                             {orgUnitPathsByNameLoading && (
                                 <OrganisationUnitTreeRootLoading dataTest="org-unit-selector-loading" />
@@ -177,15 +184,6 @@ export default function OrganisationUnitSetSelectorBarItem() {
                                         }
                                     />
                                 )}
-                        </div>
-                        <Divider margin="0" />
-                        <div className={css.labelContentContainer}>
-                            <IconBlock16 />
-                            <span className={css.label}>
-                                {i18n.t(
-                                    'Dataset is not assigned to this organisation unit'
-                                )}
-                            </span>
                         </div>
                     </div>
                 </SelectorBarItem>

--- a/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.module.css
+++ b/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.module.css
@@ -1,23 +1,25 @@
 .itemContentContainer {
-    width: 400px;
+    min-width: 400px;
     min-height: 280px;
     max-height: 70vh;
     display: flex;
-    padding: var(--spacers-dp8);
     flex-direction: column;
 }
 
 .searchInputContainer {
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--colors-grey300);
-    margin-bottom: 8px;
+    padding: var(--spacers-dp8) var(--spacers-dp8) 0;
     flex-grow: 0;
+}
+
+.dividerContainer {
+    flex-shrink: 0;
 }
 
 .orgUnitTreeContainer {
     flex-grow: 1;
     overflow: hidden;
     overflow-y: auto;
+    padding-left: var(--spacers-dp8);
 }
 
 .labelContentContainer {
@@ -36,11 +38,5 @@
 
 .disabled {
     color: var(--theme-disabled);
-    cursor: not-allowed;
-    display: flex;
-    align-items: center;
-}
-
-.disabled span {
-    margin-left: var(--spacers-dp4);
+    cursor: auto;
 }


### PR DESCRIPTION
Fixes [UX-110](https://dhis2.atlassian.net/browse/UX-110).

This PR changes the style of disabled (not available for selection) org units in the org unit selector:
- Icons are removed,
- Tooltip is shown on hover,
- Icon "legend" at bottom of menu removed,

A small change is made to the menu itself:
- Menu design is changed to remove margin around all content.

Note: the tooltip reuses the available i18n label `Dataset is not assigned to this organisation unit`, even though the label _should_ use `Data set` in two words, but it didn't seem worth the i18n change.

[UX-110]: https://dhis2.atlassian.net/browse/UX-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ