### PR TITLE
fix: metadata and user info error handling

### DIFF
--- a/src/app/load-app.js
+++ b/src/app/load-app.js
@@ -34,6 +34,7 @@ const LoadApp = ({ children }) => {
     }
 
     if (userInfo.isError) {
+        console.error(userInfo.error.message, userInfo.error.details)
         return (
             <NoticeBox
                 error
@@ -42,7 +43,7 @@ const LoadApp = ({ children }) => {
                     "There was a problem loading the user's information"
                 )}
             >
-                {userInfo.error}
+                {userInfo.error.message}
             </NoticeBox>
         )
     }

--- a/src/app/load-app.js
+++ b/src/app/load-app.js
@@ -21,13 +21,14 @@ const LoadApp = ({ children }) => {
     }
 
     if (metadata.isError) {
+        console.error(metadata.error.message, metadata.error.details)
         return (
             <NoticeBox
                 error
                 className={css.noticeBoxWrapper}
                 title={i18n.t('There was a problem loading metadata')}
             >
-                {metadata.error}
+                {metadata.error.message}
             </NoticeBox>
         )
     }


### PR DESCRIPTION
Previously, the app would crash without a helpful error message

Before:
![Screenshot 2023-02-13 at 5 02 31 PM](https://user-images.githubusercontent.com/49666798/218509470-ff9e46c4-7cfc-4cbe-bcc7-28a43b60a3a6.png)

After:
![Screenshot 2023-02-13 at 5 02 58 PM](https://user-images.githubusercontent.com/49666798/218509485-93337360-b3b2-4919-81aa-d5a50a571e93.png)
