### PR TITLE
fix(total-cell): clear total value when printing empty form

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -35,6 +35,7 @@ body {
 
     .form-cleared input,
     .form-cleared [data-test="dhis2-uicore-select-input"],
+    .form-cleared .total-cell,
     .form-cleared textarea,
     .form-cleared input+div svg /* we are adding an svg to style the checkbox which we need to hide as well in empty forms*/ {
         visibility: hidden !important;

--- a/src/data-workspace/category-combo-table-body/total-cells.js
+++ b/src/data-workspace/category-combo-table-body/total-cells.js
@@ -1,5 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import { TableCell, TableCellHead, TableRow } from '@dhis2/ui'
+import cx from 'classnames'
 import propTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import styles from '../table-body.module.css'
@@ -7,7 +8,9 @@ import { calculateColumnTotals, calculateRowTotal } from './calculate-totals.js'
 import { useValueMatrix } from './use-value-matrix.js'
 
 export const TotalCell = ({ children }) => (
-    <TableCell className={styles.totalCell}>{children}</TableCell>
+    <TableCell className={cx('total-cell', styles.totalCell)}>
+        {children}
+    </TableCell>
 )
 
 TotalCell.propTypes = {


### PR DESCRIPTION
Totals were rendered when selecting "Print empty form". This small PR adds the `.total-cell`-selector to also hide total values when a form is printed with empty values.