### PR TITLE
fix: include attribute options in completion post [DHIS2-15032]

### DIFF
--- a/src/shared/completion/use-set-form-completion-mutation.js
+++ b/src/shared/completion/use-set-form-completion-mutation.js
@@ -13,14 +13,17 @@ const MUTATION_SET_FORM_COMPLETION = {
         pe: periodId,
         ou: orgUnitId,
         cc: categoryComboId,
-        co: categoryOptionIds,
+        cp: categoryOptionIds,
         completed,
     }) => {
         return {
             dataSet: dataSetId,
             period: periodId,
             orgUnit: orgUnitId,
-            attribute: { combo: categoryComboId, options: categoryOptionIds },
+            attribute: {
+                combo: categoryComboId,
+                options: categoryOptionIds?.split(';'),
+            },
             completed,
         }
     },

--- a/src/shared/use-data-value-set/query-key-factory.js
+++ b/src/shared/use-data-value-set/query-key-factory.js
@@ -5,14 +5,14 @@ export const dataValueSets = {
         periodId,
         orgUnitId,
         categoryComboId,
-        categoryOptionIds = [],
+        categoryOptionIds,
     }) => {
         const params = {
             ds: dataSetId,
             pe: periodId,
             ou: orgUnitId,
             cc: categoryComboId,
-            cp: categoryOptionIds.join(';'),
+            cp: categoryOptionIds && categoryOptionIds.join(';'),
         }
 
         return [...dataValueSets.all, { params }]


### PR DESCRIPTION
Fixes the completion for data sets with attribute combos.

Note the backend requires attribute options in an array of options (I'd think it might be better for the backend to accept a concatenated string of these options, i.e. `cp:someUID0001;someUID0002;someUID0003` so that it matches the request format for dataValues post, but I don't think it's worth it to request a change as part of this fix)

*before*
<img width="906" alt="image" src="https://user-images.githubusercontent.com/18490902/230015398-037a534d-e369-49af-b847-3d9ff54a550d.png">
