### PR TITLE
fix: rollback failed complete [DHIS2-15033]

### DIFF
--- a/src/shared/completion/use-set-form-completion-mutation.js
+++ b/src/shared/completion/use-set-form-completion-mutation.js
@@ -72,7 +72,7 @@ export function useSetFormCompletionMutation() {
 
             return context
         },
-        onError: (event, context) => {
+        onError: (event, _, context) => {
             const alertMessage = i18n.t(
                 'Something went wrong while setting the form\'s completion to "{{completed}}": {{errorMessage}}',
                 {


### PR DESCRIPTION
fixes rollback of unsuccessful data set completion.

Note the function signature for tanstack-query onError callback: `onError: (err: TError, variables: TVariables, context?: TContext) => Promise<unknown> | unknown`