### PR TITLE
fix: use FetchError class from app-runtime [DHIS2-15085]

### DIFF
--- a/src/shared/api-errors/api-mutation-error.js
+++ b/src/shared/api-errors/api-mutation-error.js
@@ -1,3 +1,4 @@
+import { FetchError } from '@dhis2/app-runtime'
 import i18n from '../../locales/index.js'
 
 /* A dictionary taking the shape Dictionary<ErrorCode, (string | (error) => string)> to override the display message for a certain error code
@@ -28,17 +29,6 @@ const errorDetailsMessagePriority = [
     ['httpStatusCode', statusCodeErrorMessages],
 ]
 
-// FetchError is not exposed from app-runtime
-// TODO: remove once https://github.com/dhis2/app-runtime/pull/1267 is merged
-
-export class FetchError extends Error {
-    constructor({ message, type, details = {} }) {
-        super(message)
-        this.type = type
-        this.details = details
-    }
-}
-
 export class ApiMutationError extends FetchError {
     constructor({ message, type, details = {} }, mutationKey, value) {
         super({ message, type, details })
@@ -61,7 +51,4 @@ export class ApiMutationError extends FetchError {
     }
 }
 
-export const isFetchError = (error) => {
-    // instanceof does not work because FetchError is not the same class as app-runtime
-    return error.constructor.name === FetchError.name
-}
+export const isFetchError = (error) => error instanceof FetchError


### PR DESCRIPTION
Note: this error only occurred in production. The minified code does not guarantee that error.constructor.name == FetchError.name, and hence the errors are not being saved to the zustand store (e.g. see https://github.com/dhis2/aggregate-data-entry-app/blob/cf3e542e4dfdd10e6438ad33c3f0c4bc12f3beae/src/shared/data-value-mutations/data-value-mutations.js#L64-L71)

**Before**

![no_backend_error](https://user-images.githubusercontent.com/18490902/231745330-be70dd1d-bd2e-489b-a232-4faed3b37d7a.gif)

**After** 

![with_backend_error](https://user-images.githubusercontent.com/18490902/231745344-26c55428-87a5-4209-af3f-081f77543127.gif)
