### PR TITLE
fix: prevent moment from using arabic numerals for dates [DHIS2-15277]

### DIFF
--- a/src/context-selection/period-selector-bar-item/use-date-limit.js
+++ b/src/context-selection/period-selector-bar-item/use-date-limit.js
@@ -20,6 +20,7 @@ export const computePeriodDateLimit = ({
     openFuturePeriods = 0,
 }) => {
     const calendar = 'gregory'
+    // serverDate is converted to YYYY-MM-DD string named date before being passed
     const date = serverDate.toLocaleDateString('sv')
     const currentPeriod = getFixedPeriodByDate({
         periodType,

--- a/src/context-selection/period-selector-bar-item/use-date-limit.js
+++ b/src/context-selection/period-selector-bar-item/use-date-limit.js
@@ -2,7 +2,6 @@ import {
     getAdjacentFixedPeriods,
     getFixedPeriodByDate,
 } from '@dhis2/multi-calendar-dates'
-import moment from 'moment'
 import { useMemo } from 'react'
 import {
     selectors,
@@ -21,7 +20,7 @@ export const computePeriodDateLimit = ({
     openFuturePeriods = 0,
 }) => {
     const calendar = 'gregory'
-    const date = moment(serverDate).format('yyyy-MM-DD')
+    const date = serverDate.toLocaleDateString('sv')
     const currentPeriod = getFixedPeriodByDate({
         periodType,
         date,

--- a/src/context-selection/period-selector-bar-item/use-periods.js
+++ b/src/context-selection/period-selector-bar-item/use-periods.js
@@ -1,5 +1,4 @@
 import { generateFixedPeriods } from '@dhis2/multi-calendar-dates'
-import moment from 'moment'
 import { useMemo } from 'react'
 import {
     formatJsDateToDateString,
@@ -35,7 +34,7 @@ export default function usePeriods({
         const yearForGenerating = isYearlyPeriodType
             ? year + openFuturePeriods
             : year
-        const endsBefore = moment(dateLimit).format('yyyy-MM-DD')
+        const endsBefore = dateLimit.toLocaleDateString('sv')
 
         const generateFixedPeriodsPayload = {
             calendar,

--- a/src/context-selection/period-selector-bar-item/use-periods.js
+++ b/src/context-selection/period-selector-bar-item/use-periods.js
@@ -34,6 +34,7 @@ export default function usePeriods({
         const yearForGenerating = isYearlyPeriodType
             ? year + openFuturePeriods
             : year
+        // dateLimit is converted to YYYY-MM-DD string named endsBefore before being passed
         const endsBefore = dateLimit.toLocaleDateString('sv')
 
         const generateFixedPeriodsPayload = {


### PR DESCRIPTION
Noticed when looking at a radom app with rtl direction, but when I tried to select data set with language set to Arabic, the app crashed.

Turns out that the moment locale when set to `ar` formats the dates with Arabic numerals, e.g. so a date like `2022-12-03T12:00:00.000` when formatted in yyyy-MM-DD would produce this: `٢٠٢٢-١٢-٠٣`, which would not be interpretable by the various period generation functions we had and hence the app would crash (invalid date was passed).


Note: the moment/Arabic numeral format is still being used in the audits, but this does not cause any issues:
![image](https://user-images.githubusercontent.com/18490902/236840745-116ce9bf-ae75-4683-b182-9cfb513f1848.png)
