### PR TITLE
fix: handle non-standard server time zone ids [DHIS2-15511]

### DIFF
--- a/src/shared/date/use-server-time-offset.js
+++ b/src/shared/date/use-server-time-offset.js
@@ -8,9 +8,17 @@ export default function useServerTimeOffset() {
 
     return useMemo(() => {
         const currentDate = getCurrentDate()
-        const serverLocaleString = currentDate.toLocaleString('sv', {
-            timeZone,
-        })
+        let serverLocaleString
+        try {
+            serverLocaleString = currentDate.toLocaleString('sv', {
+                timeZone,
+            })
+        } catch (e) {
+            console.error(e)
+            console.info('Assuming no server/client time zone difference')
+            serverLocaleString = currentDate.toLocaleString('sv')
+        }
+
         const nowAtServerTimeZone = new Date(serverLocaleString)
         const currentDateTime = currentDate.getTime()
         const nowAtServerTimeZoneTime = nowAtServerTimeZone.getTime()

--- a/src/shared/date/use-server-time-offset.test.js
+++ b/src/shared/date/use-server-time-offset.test.js
@@ -49,4 +49,16 @@ describe('useServerTimeOffset', () => {
 
         expect(actual).toBe(expected)
     })
+
+    it('returns no offset when server time zone is invalid', () => {
+        const timeZone = 'Invalid time zone'
+        const systemInfo = { serverTimeZoneId: timeZone }
+        useConfig.mockReturnValue({ systemInfo })
+
+        const expected = 0
+        const { result } = renderHook(() => useServerTimeOffset())
+        const actual = result.current
+
+        expect(actual).toBe(expected)
+    })
 })


### PR DESCRIPTION
This PR addresses an immediate issue where the data entry app is crashing when the `serverTimeZoneId` returned from api/system/info. In the case reported by user, the serverTimeZoneId was `GMT+08:00` instead of the equivalent IANA database format (`Etc/GMT-8`), which is expected by javascript. Bug report is [DHIS2-15511](https://dhis2.atlassian.net/browse/DHIS2-15511)

FYI. There's a much longer discussion on the related ticket [DHIS2-15361](https://dhis2.atlassian.net/browse/DHIS2-15361) about why this is occurring, which could then inform how we generally want to handle this on the front end going forward. For now, this PR just prevents the app from crashing in the case (and then assumes no client/server time zone difference, thus letting backend enforce any time boundaries). Note that in the useTimeZoneConversion hook we added to app-runtime already includes [logic](https://github.com/dhis2/app-runtime/blob/master/services/config/src/useTimeZoneConversion.ts#L89-L101) to handle non-recognizable time zones (and also assumes no client/server time zone difference in such a case).

Note I just tested this by overriding the timezone value directly in the app as I didn't want to try to update my java settings.



[DHIS2-15511]: https://dhis2.atlassian.net/browse/DHIS2-15511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15361]: https://dhis2.atlassian.net/browse/DHIS2-15361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ