### PR TITLE
fix: handle indicator decimals [DHIS2-15631]

### DIFF
--- a/src/data-workspace/custom-form/replace-td-node.js
+++ b/src/data-workspace/custom-form/replace-td-node.js
@@ -12,6 +12,7 @@ const replaceIndicatorCell = (indicatorId, metadata) => {
         denominator,
         numerator,
         indicatorType: { factor },
+        decimals,
     } = metadata.indicators[indicatorId]
 
     return (
@@ -19,6 +20,7 @@ const replaceIndicatorCell = (indicatorId, metadata) => {
             denominator={denominator}
             numerator={numerator}
             factor={factor}
+            decimals={decimals}
         />
     )
 }

--- a/src/data-workspace/indicators-table-body/compute-indicator-value.js
+++ b/src/data-workspace/indicators-table-body/compute-indicator-value.js
@@ -94,6 +94,24 @@ const parseExpressionTemplate = (expression, values) => {
         return substitudedExpression.replace(match, value)
     }, expression)
 }
+
+/*
+ * round(value, decimals)
+ *
+ * @param {number} value unrounded computed indicactorValue
+ * @param {number} decimals number of decimal places to include output
+ * @returns {number} number rounded to number of decimals
+ */
+
+export const round = (value, decimals) => {
+    if (decimals < 0 || !Number.isInteger(decimals)) {
+        return value
+    }
+    // Math.round only rounds to whole digit, so multiply by 10^x, round, then divide by 10^x
+    const factor = Math.pow(10, decimals)
+    return Math.round(value * factor) / factor
+}
+
 /**
  * Parses and evaluates the denominator and numerator expressions
  * and then computes the indicator value
@@ -110,6 +128,7 @@ export const computeIndicatorValue = ({
     numerator,
     factor,
     formState,
+    decimals,
 }) => {
     const numeratorExpression = parseExpressionTemplate(
         numerator,
@@ -123,6 +142,8 @@ export const computeIndicatorValue = ({
     const denominatorValue = evaluate(denominatorExpression)
     const indicatorValue = (numeratorValue / denominatorValue) * factor
     const isReadableNumber = isFinite(indicatorValue) && !isNaN(indicatorValue)
-
-    return isReadableNumber ? indicatorValue : ''
+    if (!isReadableNumber) {
+        return ''
+    }
+    return decimals ? round(indicatorValue, decimals) : indicatorValue
 }

--- a/src/data-workspace/indicators-table-body/compute-indicator-value.test.js
+++ b/src/data-workspace/indicators-table-body/compute-indicator-value.test.js
@@ -1,4 +1,4 @@
-import { computeIndicatorValue } from './compute-indicator-value.js'
+import { computeIndicatorValue, round } from './compute-indicator-value.js'
 
 describe('computeIndicatorValue', () => {
     const formState = {
@@ -66,5 +66,60 @@ describe('computeIndicatorValue', () => {
             formState,
         })
         expect(value).toBe('')
+    })
+    it('returns an appropriately rounded value', () => {
+        const value = computeIndicatorValue({
+            numerator: '#{a.a1}', // 1
+            denominator: '#{c.c1}', // 3
+            factor: 100,
+            formState,
+            decimals: 3,
+        })
+        expect(value).toBe(33.333)
+    })
+})
+
+describe('round', () => {
+    it('rounds to 2 values if decimals is 2', () => {
+        const decimals = 2
+        const originalValue = 3.1415926
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(3.14)
+    })
+    it('rounds to whole number if decimals is 0', () => {
+        const decimals = 0
+        const originalValue = 3.1415926
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(3)
+    })
+    it('rounds down if original value is negative', () => {
+        const decimals = 1
+        const originalValue = -3.1415926
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(-3.1)
+    })
+    it('returns NaN if original value is NaN', () => {
+        const decimals = 3
+        const originalValue = NaN
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(originalValue)
+    })
+    it('returns the original value if decimals is not provided', () => {
+        const decimals = undefined
+        const originalValue = 3.1415926
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(originalValue)
+    })
+    it('returns the original value if decimals is not an integer', () => {
+        const decimals = 2.71828
+        const originalValue = 3.1415926
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(originalValue)
+    })
+    it('returns the original value if decimals is negative', () => {
+        const decimals = -4
+        const originalValue = 3.1415926
+        const roundedValue = round(originalValue, decimals)
+        expect(roundedValue).toBe(originalValue)
     })
 })

--- a/src/data-workspace/indicators-table-body/indicator-table-cell.js
+++ b/src/data-workspace/indicators-table-body/indicator-table-cell.js
@@ -6,7 +6,12 @@ import { useBlurredField } from '../../shared/index.js'
 import styles from '../table-body.module.css'
 import { useIndicatorValue } from './use-indicator-value.js'
 
-export const IndicatorTableCell = ({ denominator, factor, numerator }) => {
+export const IndicatorTableCell = ({
+    denominator,
+    factor,
+    numerator,
+    decimals,
+}) => {
     const form = useForm()
     const blurredField = useBlurredField()
     const indicatorValue = useIndicatorValue({
@@ -15,6 +20,7 @@ export const IndicatorTableCell = ({ denominator, factor, numerator }) => {
         factor,
         form,
         numerator,
+        decimals,
     })
 
     return (
@@ -26,4 +32,5 @@ IndicatorTableCell.propTypes = {
     denominator: PropTypes.string.isRequired,
     factor: PropTypes.number.isRequired,
     numerator: PropTypes.string.isRequired,
+    decimals: PropTypes.number,
 }

--- a/src/data-workspace/indicators-table-body/indicators-table-body.js
+++ b/src/data-workspace/indicators-table-body/indicators-table-body.js
@@ -58,6 +58,7 @@ export const IndicatorsTableBody = ({
                             denominator={indicator.denominator}
                             numerator={indicator.numerator}
                             factor={indicator.indicatorType.factor}
+                            decimals={indicator.decimals}
                         />
                         {padColumns.map((_, i) => (
                             <TableCell

--- a/src/data-workspace/indicators-table-body/use-indicator-value.js
+++ b/src/data-workspace/indicators-table-body/use-indicator-value.js
@@ -23,6 +23,7 @@ export const useIndicatorValue = ({
     factor,
     form,
     numerator,
+    decimals,
 }) => {
     const indicatorValueRef = useRef(null)
     const affectedDataElementsLookup = useMemo(
@@ -57,6 +58,7 @@ export const useIndicatorValue = ({
                 numerator,
                 factor,
                 formState: form.getState(),
+                decimals,
             })
         }
 
@@ -68,5 +70,6 @@ export const useIndicatorValue = ({
         factor,
         form,
         numerator,
+        decimals,
     ])
 }


### PR DESCRIPTION
This adds functionality to round indicators if they have decimals specified for their output.

**Before**
<img width="910" alt="image" src="https://github.com/dhis2/aggregate-data-entry-app/assets/18490902/6a14ab3a-468c-4193-97c2-aa537abeca40">

**After**
<img width="837" alt="image" src="https://github.com/dhis2/aggregate-data-entry-app/assets/18490902/7609d04a-7a0b-4392-bdb0-6ab2625085ec">

Note: when I looked at the legacy data entry app seems to just round to 1 decimal if decimals were specified (and did not follow the actual number of decimals specified). I assume we don't want to do that. I checked against how the decimals were displaying in visualizer and tried to be consistent with that:
<img width="800" alt="image" src="https://github.com/dhis2/aggregate-data-entry-app/assets/18490902/6c59c04a-4224-4aa3-93ab-d493a493a3fb">
visualizer app is also not add trailing 0s if indicator has more specified decimals than necessary (e.g. if the indicator is 2/4 and it has 5 decimals specified, it will only display as .5 and not as .50000, so I have not added any trailing 0s for the data entry app)
