### PR TITLE
test: publish jest test results to reportportal

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -84,6 +84,8 @@ jobs:
               run: yarn d2-app-scripts test
               env:
                   REPORTPORTAL_API_KEY: ${{ secrets.REPORTPORTAL_API_KEY }}
+                  REPORTPORTAL_ENDPOINT: ${{ secrets.REPORTPORTAL_ENDPOINT }}
+                  REPORTPORTAL_PROJECT: ${{ secrets.REPORTPORTAL_PROJECT }}
 
     e2e:
         runs-on: ubuntu-latest
@@ -122,6 +124,8 @@ jobs:
                   CYPRESS_dhis2ApiVersion: 40
                   CYPRESS_networkMode: stub
                   REPORTPORTAL_API_KEY: ${{ secrets.REPORTPORTAL_API_KEY }}
+                  REPORTPORTAL_ENDPOINT: ${{ secrets.REPORTPORTAL_ENDPOINT }}
+                  REPORTPORTAL_PROJECT: ${{ secrets.REPORTPORTAL_PROJECT }}
 
     release:
         runs-on: ubuntu-latest

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -82,6 +82,8 @@ jobs:
 
             - name: Test
               run: yarn d2-app-scripts test
+              env:
+                  REPORTPORTAL_API_KEY: ${{ secrets.REPORTPORTAL_API_KEY }}
 
     e2e:
         runs-on: ubuntu-latest

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -84,8 +84,8 @@ jobs:
               run: yarn d2-app-scripts test
               env:
                   REPORTPORTAL_API_KEY: ${{ secrets.REPORTPORTAL_API_KEY }}
-                  REPORTPORTAL_ENDPOINT: ${{ secrets.REPORTPORTAL_ENDPOINT }}
-                  REPORTPORTAL_PROJECT: ${{ secrets.REPORTPORTAL_PROJECT }}
+                  REPORTPORTAL_ENDPOINT: ${{ vars.REPORTPORTAL_ENDPOINT }}
+                  REPORTPORTAL_PROJECT: ${{ vars.REPORTPORTAL_PROJECT }}
 
     e2e:
         runs-on: ubuntu-latest
@@ -124,8 +124,8 @@ jobs:
                   CYPRESS_dhis2ApiVersion: 40
                   CYPRESS_networkMode: stub
                   REPORTPORTAL_API_KEY: ${{ secrets.REPORTPORTAL_API_KEY }}
-                  REPORTPORTAL_ENDPOINT: ${{ secrets.REPORTPORTAL_ENDPOINT }}
-                  REPORTPORTAL_PROJECT: ${{ secrets.REPORTPORTAL_PROJECT }}
+                  REPORTPORTAL_ENDPOINT: ${{ vars.REPORTPORTAL_ENDPOINT }}
+                  REPORTPORTAL_PROJECT: ${{ vars.REPORTPORTAL_PROJECT }}
 
     release:
         runs-on: ubuntu-latest

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -22,10 +22,10 @@ module.exports = defineConfig({
     defaultCommandTimeout: 30000,
     reporter: '@reportportal/agent-js-cypress',
     reporterOptions: {
-        endpoint: 'https://test.tools.dhis2.org/reportportal/api/v1',
+        endpoint: process.env.REPORTPORTAL_ENDPOINT,
         apiKey: process.env.REPORTPORTAL_API_KEY,
         launch: 'aggregate_data_entry_app_master',
-        project: 'dhis2_auto',
+        project: process.env.REPORTPORTAL_PROJECT,
         description: '',
         autoMerge: true,
         parallel: true,
@@ -41,6 +41,10 @@ module.exports = defineConfig({
             {
                 key: 'app_name',
                 value: 'aggregate_data_entry_app',
+            },
+            {
+                key: 'test_level',
+                value: 'e2e',
             },
         ],
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,8 +16,8 @@ module.exports = {
             '@reportportal/agent-js-jest',
             {
                 apiKey: process.env.REPORTPORTAL_API_KEY,
-                endpoint: 'https://test.tools.dhis2.org/reportportal/api/v1',
-                project: 'dhis2_auto',
+                endpoint: process.env.REPORTPORTAL_ENDPOINT,
+                project: process.env.REPORTPORTAL_PROJECT,
                 launch: 'aggregate_data_entry_app_master',
                 attributes: [
                     {

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,33 @@ module.exports = {
     moduleNameMapper: {
         '\\.css$': 'identity-obj-proxy',
     },
+    testRunner: 'jest-circus/runner',
+    reporters: [
+        'default',
+        [
+            '@reportportal/agent-js-jest',
+            {
+                apiKey: process.env.REPORTPORTAL_API_KEY,
+                endpoint: 'https://test.tools.dhis2.org/reportportal/api/v1',
+                project: 'dhis2_auto',
+                launch: 'aggregate_data_entry_app_master',
+                attributes: [
+                    {
+                        key: 'version',
+                        value: 'master',
+                    },
+                    {
+                        key: 'app_name',
+                        value: 'aggregate_data_entry_app',
+                    },
+                    {
+                        key: 'test_level',
+                        value: 'unit/integration',
+                    },
+                ],
+                description: '',
+                debug: true,
+            },
+        ],
+    ],
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@dhis2/cypress-commands": "^10.0.1",
         "@dhis2/cypress-plugins": "^10.0.1",
         "@reportportal/agent-js-cypress": "^5.1.3",
+        "@reportportal/agent-js-jest": "^5.0.6",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "12.1.5",
         "@testing-library/react-hooks": "7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3363,6 +3363,14 @@
     mocha "^10.2.0"
     node-ipc "9.1.1"
 
+"@reportportal/agent-js-jest@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@reportportal/agent-js-jest/-/agent-js-jest-5.0.6.tgz#336ed06c3c80d70bd8e50824bc3c883cb5d2548e"
+  integrity sha512-Gt2oOZ/k5HxZ2J3Hb6X43y6XZmvpldt3yM2wPdrU5CPhXb9hxdiZUl+e2MfI3y0aB+d6T/AkKcUyT7f91sZaYw==
+  dependencies:
+    "@reportportal/client-javascript" "^5.0.12"
+    strip-ansi "^6.0.1"
+
 "@reportportal/client-javascript@^5.0.12":
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/@reportportal/client-javascript/-/client-javascript-5.0.12.tgz#b6d9254014545ca56599c05105854ea814561f1e"


### PR DESCRIPTION
After the previous PR that sends Cypress test results to the ReportPortal dashboard (https://github.com/dhis2/aggregate-data-entry-app/pull/349),

This second PR sends now Jest test results to ReportPortal:
<img width="1651" alt="image" src="https://github.com/dhis2/aggregate-data-entry-app/assets/125370676/258b97da-6064-4d60-ba13-279599b52cf3">

<img width="954" alt="image" src="https://github.com/dhis2/aggregate-data-entry-app/assets/125370676/56c743de-49c7-4281-9829-b6830441ca68">
