### PR TITLE
fix: add message when year has no periods [DHIS2-14444]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-05-09T13:28:08.215Z\n"
-"PO-Revision-Date: 2023-05-09T13:28:08.215Z\n"
+"POT-Creation-Date: 2023-08-10T08:31:47.096Z\n"
+"PO-Revision-Date: 2023-08-10T08:31:47.096Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -293,6 +293,9 @@ msgstr "Fetching organisation unit info"
 
 msgid "Error occurred while loading organisation unit info"
 msgstr "Error occurred while loading organisation unit info"
+
+msgid "No periods available in this year"
+msgstr "No periods available in this year"
 
 msgid "The Period ({{id}}) is not open or is invalid."
 msgstr "The Period ({{id}}) is not open or is invalid."

--- a/src/context-selection/period-selector-bar-item/period-menu.js
+++ b/src/context-selection/period-selector-bar-item/period-menu.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import { Menu, MenuItem } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -7,6 +8,14 @@ import classes from './period-menu.module.css'
 export default function PeriodMenu({ onChange, periods }) {
     const [periodId] = usePeriodId()
     const selectedPeriod = usePeriod(periodId)
+
+    if (periods.length === 0) {
+        return (
+            <div className={classes.noPeriods}>
+                {i18n.t('No periods available in this year')}
+            </div>
+        )
+    }
 
     return (
         <Menu dense className={classes.menu} dataTest="period-selector-menu">

--- a/src/context-selection/period-selector-bar-item/period-menu.module.css
+++ b/src/context-selection/period-selector-bar-item/period-menu.module.css
@@ -3,3 +3,11 @@
     min-width: 240px;
     overflow: auto;
 }
+
+.noPeriods {
+    color: var(--colors-grey600);
+    text-align: center;
+    padding: 8px;
+    font-size: 14px;
+    width: 240px;
+}


### PR DESCRIPTION
See ticket: https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-14444

Adds a message when there are no periods that are selectable in the current year:

<img width="705" alt="image" src="https://github.com/dhis2/aggregate-data-entry-app/assets/18490902/1848304b-0adb-41ca-8818-f257be8e7843">

Joe approved the design / message over slack.
