### PR TITLE
fix(validator): limits as warning instead of error

### DIFF
--- a/src/context-selection/contextual-help-sidebar/cell.js
+++ b/src/context-selection/contextual-help-sidebar/cell.js
@@ -12,6 +12,7 @@ const Cell = ({ value, state }) => (
                     [styles.inputInvalid]: state === 'INVALID',
                     [styles.inputSynced]: state === 'SYNCED',
                     [styles.inputLocked]: state === 'LOCKED',
+                    [styles.inputWarning]: state === 'WARNING',
                 })}
             >
                 {value}

--- a/src/context-selection/contextual-help-sidebar/cell.module.css
+++ b/src/context-selection/contextual-help-sidebar/cell.module.css
@@ -26,6 +26,10 @@
     cursor: not-allowed;
 }
 
+.inputWarning {
+    composes: warning from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
+}
+
 .topRightIndicator {
     composes: topRightIndicator from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
 }

--- a/src/context-selection/contextual-help-sidebar/cells-legend.js
+++ b/src/context-selection/contextual-help-sidebar/cells-legend.js
@@ -58,6 +58,12 @@ export default function CellsLegend() {
             <Divider />
 
             <CellsLegendSymbol
+                name={i18n.t('Warning, saved')}
+                state="WARNING"
+            />
+            <Divider />
+
+            <CellsLegendSymbol
                 name={i18n.t('Locked, not editable')}
                 state="LOCKED"
             />

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -57,7 +57,7 @@
 
 .warning:not(.active) {
     background: var(--colors-yellow100);
-    outline: 1px solid var(--colors-red600);
+    outline: 1px solid var(--colors-yellow300);
 }
 
 .warning:hover {

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -39,7 +39,6 @@
     z-index: 1;
 }
 
-
 .highlighted.active {
     outline-color: var(--theme-focus) !important;
 }
@@ -54,6 +53,15 @@
         var(--colors-grey200) 0,
         var(--colors-grey200) 50%
     );
+}
+
+.warning:not(.active) {
+    background: var(--colors-yellow100);
+    outline: 1px solid var(--colors-red600);
+}
+
+.warning:hover {
+    background: var(--colors-yellow200);
 }
 
 .invalid:not(.active) {
@@ -71,7 +79,6 @@
 .synced:hover {
     background: #d8eeda;
 }
-
 
 .topRightIndicator {
     position: absolute;
@@ -111,6 +118,6 @@
 
 @media print {
     .hideForPrint {
-        composes: hideForPrint from '../../app/app.css'
+        composes: hideForPrint from '../../app/app.css';
     }
 }

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -143,7 +143,7 @@ export function InnerWrapper({
         <ValidationTooltip
             fieldname={fieldname}
             active={active}
-            invalid={warning || invalid || !!syncError}
+            enabled={!!warning || invalid || !!syncError}
             content={errorMessage}
         >
             <div

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -9,6 +9,7 @@ import {
     useDataValueParams,
     useValueStore,
     useSyncErrorsStore,
+    useEntryFormStore,
 } from '../../shared/index.js'
 import styles from './data-entry-cell.module.css'
 import { ValidationTooltip } from './validation-tooltip.js'
@@ -94,22 +95,27 @@ export function InnerWrapper({
     const clearSyncError = useSyncErrorsStore(
         (state) => state.clearErrorByDataValueParams
     )
+    const warning = useEntryFormStore((state) => state.getWarning(fieldname))
+    const fieldErrorMessage = error ?? warning
 
     const errorMessage =
         error && syncError ? (
             <div className={styles.validationTooltipMessage}>
-                <div>{error}</div>
+                <div>{fieldErrorMessage}</div>
                 <div>{syncError.displayMessage}</div>
             </div>
         ) : (
-            error ?? syncError?.displayMessage
+            fieldErrorMessage ?? syncError?.displayMessage
         )
+
     const valueSynced = data.lastSyncedValue === value
     const showSynced = dirty && valueSynced
     // todo: maybe use mutation state to improve this style handling
     // see https://dhis2.atlassian.net/browse/TECH-1316
     const cellStateClassName = invalid
         ? styles.invalid
+        : warning
+        ? styles.warning
         : activeMutations === 0 && showSynced
         ? styles.synced
         : null
@@ -137,7 +143,7 @@ export function InnerWrapper({
         <ValidationTooltip
             fieldname={fieldname}
             active={active}
-            invalid={invalid || !!syncError}
+            invalid={warning || invalid || !!syncError}
             content={errorMessage}
         >
             <div

--- a/src/data-workspace/data-entry-cell/validation-tooltip.js
+++ b/src/data-workspace/data-entry-cell/validation-tooltip.js
@@ -6,18 +6,17 @@ import styles from './data-entry-cell.module.css'
 /**
  * These components adapt the UI Tooltip component to be used for the
  * validation feedback tooltip in DE cells, which has a few needs:
- * 1. Should only open when the cell state is invalid
- * 2. Should gracefully close when the cell becomes valid again
- * 3. Should not cause cell to lose focus when it becomes invalid
+ * 1. Should only open when enabled prop is true
+ * 2. Should gracefully close when the enabled props becomes false
+ * 3. Should not cause cell to lose focus when tooltip is opened
  * 4. Should open when focused and close when defocused
  */
-
 const TooltipManager = React.forwardRef(function TooltipManager(
-    { active, children, invalid, onMouseOut: close, onMouseOver: open },
+    { active, children, enabled, onMouseOut: close, onMouseOver: open },
     ref
 ) {
     React.useEffect(() => {
-        if (invalid && active) {
+        if (enabled && active) {
             open()
         }
         // When this cell becomes valid or defocused, close the tooltip
@@ -28,17 +27,17 @@ const TooltipManager = React.forwardRef(function TooltipManager(
         // when included, useEffect refires and causes tooltip to flicker
         // TODO add onMouseOut, onMouseOver once https://dhis2.atlassian.net/browse/LIBS-359 is fixed
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [invalid, active])
+    }, [enabled, active])
 
     // Only open the tooltip if the cell is invalid
     const handleMouseOver = () => {
-        if (invalid) {
+        if (enabled) {
             open()
         }
     }
     // Close on mouseout if invalid cell is not active
     const handleMouseOut = () => {
-        if (invalid && !active) {
+        if (enabled && !active) {
             close()
         }
     }
@@ -57,16 +56,16 @@ const TooltipManager = React.forwardRef(function TooltipManager(
 TooltipManager.propTypes = {
     active: PropTypes.bool,
     children: PropTypes.node,
-    invalid: PropTypes.bool,
+    enabled: PropTypes.bool,
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
 }
 
-export const ValidationTooltip = ({ children, content, invalid, active }) => {
+export const ValidationTooltip = ({ children, content, enabled, active }) => {
     return (
         <Tooltip content={content}>
             {(props) => (
-                <TooltipManager {...props} invalid={invalid} active={active}>
+                <TooltipManager {...props} enabled={enabled} active={active}>
                     {children}
                 </TooltipManager>
             )}
@@ -77,6 +76,6 @@ ValidationTooltip.propTypes = {
     active: PropTypes.bool,
     children: PropTypes.node,
     content: PropTypes.string,
+    enabled: PropTypes.bool,
     fieldname: PropTypes.string,
-    invalid: PropTypes.bool,
 }

--- a/src/data-workspace/inputs/generic-input.js
+++ b/src/data-workspace/inputs/generic-input.js
@@ -13,7 +13,6 @@ import styles from './inputs.module.css'
 import { InputPropTypes } from './utils.js'
 import {
     validateByValueType,
-    limitValidator,
     warningValidateByValueType,
 } from './validators.js'
 
@@ -53,14 +52,15 @@ export const GenericInput = ({
     }
     const setWarning = useEntryFormStore((state) => state.setWarning)
 
+    const warningValidate = (value) => {
+        const warningValidator = warningValidateByValueType(valueType, limits)
+        const warningValidationResult = warningValidator(value)
+        setWarning(fieldname, warningValidationResult)
+    }
+
     const { input, meta } = useField(fieldname, {
         validate: (value) => {
-            const warningValidator = warningValidateByValueType(
-                valueType,
-                limits
-            )
-            const warningValidationResult = warningValidator(value)
-            setWarning(fieldname, warningValidationResult)
+            warningValidate(value)
             return validateByValueType(valueType, limits)(value)
         },
         subscription: {

--- a/src/data-workspace/inputs/generic-input.js
+++ b/src/data-workspace/inputs/generic-input.js
@@ -5,12 +5,17 @@ import { useField } from 'react-final-form'
 import {
     NUMBER_TYPES,
     VALUE_TYPES,
+    useEntryFormStore,
     useSetDataValueMutation,
 } from '../../shared/index.js'
 import { useMinMaxLimits } from '../use-min-max-limits.js'
 import styles from './inputs.module.css'
 import { InputPropTypes } from './utils.js'
-import { validateByValueTypeWithLimits } from './validators.js'
+import {
+    validateByValueType,
+    limitValidator,
+    warningValidateByValueType,
+} from './validators.js'
 
 const htmlTypeAttrsByValueType = {
     [VALUE_TYPES.DATE]: 'date',
@@ -46,9 +51,24 @@ export const GenericInput = ({
             return value.trim()
         }
     }
+    const setWarning = useEntryFormStore((state) => state.setWarning)
+
     const { input, meta } = useField(fieldname, {
-        validate: validateByValueTypeWithLimits(valueType, limits),
-        subscription: { value: true, dirty: true, valid: true, data: true },
+        validate: (value) => {
+            const warningValidator = warningValidateByValueType(
+                valueType,
+                limits
+            )
+            const warningValidationResult = warningValidator(value)
+            setWarning(fieldname, warningValidationResult)
+            return validateByValueType(valueType, limits)(value)
+        },
+        subscription: {
+            value: true,
+            dirty: true,
+            valid: true,
+            data: true,
+        },
         format: formatValue,
         formatOnBlur: true,
         // This is required to ensure form is validated on first page load

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -87,12 +87,18 @@ export const validatorsByValueType = {
     [VALUE_TYPES.URL]: url,
 }
 
-export const validateByValueTypeWithLimits = (valueType, limits) => {
+export const validateByValueType = (valueType) => {
     const validators = []
 
     if (validatorsByValueType[valueType]) {
         validators.push(validatorsByValueType[valueType])
     }
+
+    return composeValidators(...validators)
+}
+
+export const warningValidateByValueType = (valueType, limits) => {
+    const validators = []
 
     if (
         CAN_HAVE_LIMITS_TYPES.includes(valueType) &&

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -88,27 +88,19 @@ export const validatorsByValueType = {
 }
 
 export const validateByValueType = (valueType) => {
-    const validators = []
-
-    if (validatorsByValueType[valueType]) {
-        validators.push(validatorsByValueType[valueType])
-    }
-
-    return composeValidators(...validators)
+    const validator = validatorsByValueType[valueType]
+    return validator ? validator : () => undefined
 }
 
 export const warningValidateByValueType = (valueType, limits) => {
-    const validators = []
-
     if (
         CAN_HAVE_LIMITS_TYPES.includes(valueType) &&
         Number.isFinite(limits?.min) &&
         Number.isFinite(limits?.max)
     ) {
-        validators.push(createNumberRange(limits.min, limits.max))
+        return createNumberRange(limits.min, limits.max)
     }
-
-    return composeValidators(...validators)
+    return () => undefined
 }
 
 export const minMaxValidatorsByValueType = {

--- a/src/data-workspace/inputs/validators.test.js
+++ b/src/data-workspace/inputs/validators.test.js
@@ -1,5 +1,5 @@
 import { VALUE_TYPES, CAN_HAVE_LIMITS_TYPES } from '../../shared/index.js'
-import { validateByValueTypeWithLimits } from './validators.js'
+import { validateByValueType } from './validators.js'
 
 describe(`validateByValueTypeWithLimits`, () => {
     describe(`when limits are defined`, () => {
@@ -29,7 +29,7 @@ describe(`validateByValueTypeWithLimits`, () => {
         ])(
             'should return error for %s type that supports limits where value is outside of bounds',
             ({ valueType, value, min, max, expectedErrorMessage }) => {
-                const errorMessage = validateByValueTypeWithLimits(valueType, {
+                const errorMessage = validateByValueType(valueType, {
                     min,
                     max,
                 })(value)
@@ -39,7 +39,7 @@ describe(`validateByValueTypeWithLimits`, () => {
 
         it('should not return error for type that support limits and is in bounds', () => {
             expect(
-                validateByValueTypeWithLimits(VALUE_TYPES.NUMBER, {
+                validateByValueType(VALUE_TYPES.NUMBER, {
                     min: 5,
                     max: 10,
                 })(7)
@@ -48,7 +48,7 @@ describe(`validateByValueTypeWithLimits`, () => {
 
         it('should not return error for type that does not support limits', () => {
             expect(
-                validateByValueTypeWithLimits(VALUE_TYPES.TEXT, {
+                validateByValueType(VALUE_TYPES.TEXT, {
                     min: 5,
                     max: 10,
                 })(`asdf`)
@@ -59,13 +59,13 @@ describe(`validateByValueTypeWithLimits`, () => {
     describe(`when limits are undefined`, () => {
         it('should not return error', () => {
             expect(
-                validateByValueTypeWithLimits(VALUE_TYPES.INTEGER, undefined)(4)
+                validateByValueType(VALUE_TYPES.INTEGER, undefined)(4)
             ).toBeUndefined()
         })
 
         it('should not return error for type that support limits and only has min defined', () => {
             expect(
-                validateByValueTypeWithLimits(VALUE_TYPES.NUMBER, {
+                validateByValueType(VALUE_TYPES.NUMBER, {
                     min: 5,
                 })(7)
             ).toBeUndefined()
@@ -73,7 +73,7 @@ describe(`validateByValueTypeWithLimits`, () => {
 
         it('should not return error for type that support limits and only has min defined', () => {
             expect(
-                validateByValueTypeWithLimits(VALUE_TYPES.NUMBER, {
+                validateByValueType(VALUE_TYPES.NUMBER, {
                     max: 10,
                 })(7)
             ).toBeUndefined()

--- a/src/data-workspace/inputs/validators.test.js
+++ b/src/data-workspace/inputs/validators.test.js
@@ -1,5 +1,8 @@
 import { VALUE_TYPES, CAN_HAVE_LIMITS_TYPES } from '../../shared/index.js'
-import { validateByValueType } from './validators.js'
+import {
+    validateByValueType,
+    warningValidateByValueType,
+} from './validators.js'
 
 describe(`validateByValueTypeWithLimits`, () => {
     describe(`when limits are defined`, () => {
@@ -12,8 +15,6 @@ describe(`validateByValueTypeWithLimits`, () => {
                     value: 4,
                     min: 5,
                     max: 10,
-                    expectedErrorMessage:
-                        'Number cannot be less than 5 or more than 10',
                 },
             ]),
             [
@@ -22,18 +23,17 @@ describe(`validateByValueTypeWithLimits`, () => {
                     value: -4,
                     min: -10,
                     max: -5,
-                    expectedErrorMessage:
-                        'Number cannot be less than -10 or more than -5',
                 },
             ],
         ])(
-            'should return error for %s type that supports limits where value is outside of bounds',
-            ({ valueType, value, min, max, expectedErrorMessage }) => {
+            'should not return error for %s type that supports limits where value is outside of bounds',
+            ({ valueType, value, min, max }) => {
+                // limits are handled as warnings - not errors!
                 const errorMessage = validateByValueType(valueType, {
                     min,
                     max,
                 })(value)
-                expect(errorMessage).toEqual(expectedErrorMessage)
+                expect(errorMessage).toEqual(undefined)
             }
         )
 
@@ -74,6 +74,98 @@ describe(`validateByValueTypeWithLimits`, () => {
         it('should not return error for type that support limits and only has min defined', () => {
             expect(
                 validateByValueType(VALUE_TYPES.NUMBER, {
+                    max: 10,
+                })(7)
+            ).toBeUndefined()
+        })
+
+        it('should return error when valueType is number and value is not a number', () => {
+            expect(validateByValueType(VALUE_TYPES.NUMBER, {})('asdf')).toEqual(
+                'Please provide a number'
+            )
+        })
+
+        it('should return error when not a valid percentage', () => {
+            expect(
+                validateByValueType(VALUE_TYPES.PERCENTAGE, {})(101)
+            ).toEqual('Number cannot be less than 0 or more than 100')
+        })
+    })
+})
+
+describe('warningValidateByValueType', () => {
+    describe(`when limits are defined`, () => {
+        it.each([
+            ...CAN_HAVE_LIMITS_TYPES.filter(
+                (valueType) => valueType !== VALUE_TYPES.INTEGER_NEGATIVE
+            ).map((valueType) => [
+                {
+                    valueType,
+                    value: 4,
+                    min: 5,
+                    max: 10,
+                    expectedErrorMessage:
+                        'Number cannot be less than 5 or more than 10',
+                },
+            ]),
+            [
+                {
+                    valueType: VALUE_TYPES.INTEGER_NEGATIVE,
+                    value: -4,
+                    min: -10,
+                    max: -5,
+                    expectedErrorMessage:
+                        'Number cannot be less than -10 or more than -5',
+                },
+            ],
+        ])(
+            'should return error for %s type that supports limits where value is outside of bounds',
+            ({ valueType, value, min, max, expectedErrorMessage }) => {
+                const errorMessage = warningValidateByValueType(valueType, {
+                    min,
+                    max,
+                })(value)
+                expect(errorMessage).toEqual(expectedErrorMessage)
+            }
+        )
+
+        it('should not return error for type that support limits and is in bounds', () => {
+            expect(
+                warningValidateByValueType(VALUE_TYPES.NUMBER, {
+                    min: 5,
+                    max: 10,
+                })(7)
+            ).toBeUndefined()
+        })
+
+        it('should not return error for type that does not support limits', () => {
+            expect(
+                warningValidateByValueType(VALUE_TYPES.TEXT, {
+                    min: 5,
+                    max: 10,
+                })(`asdf`)
+            ).toBeUndefined()
+        })
+    })
+
+    describe(`when limits are undefined`, () => {
+        it('should not return error', () => {
+            expect(
+                warningValidateByValueType(VALUE_TYPES.INTEGER, undefined)(4)
+            ).toBeUndefined()
+        })
+
+        it('should not return error for type that support limits and only has min defined', () => {
+            expect(
+                warningValidateByValueType(VALUE_TYPES.NUMBER, {
+                    min: 5,
+                })(7)
+            ).toBeUndefined()
+        })
+
+        it('should not return error for type that support limits and only has min defined', () => {
+            expect(
+                warningValidateByValueType(VALUE_TYPES.NUMBER, {
                     max: 10,
                 })(7)
             ).toBeUndefined()

--- a/src/shared/stores/entry-form-store.js
+++ b/src/shared/stores/entry-form-store.js
@@ -16,7 +16,7 @@ export const useEntryFormStore = create((set, get) => ({
     setWarning: (fieldname, warning) => {
         const warnings = get().getWarnings()
         // setIn from final-form is used to create the same structure as errors
-        const newWarnings = setIn(warnings, fieldname, warning)
+        const newWarnings = setIn(warnings, fieldname, warning) ?? {}
         set({ warnings: newWarnings })
     },
     // could add getNumberOfWarnings if needed

--- a/src/shared/stores/entry-form-store.js
+++ b/src/shared/stores/entry-form-store.js
@@ -1,26 +1,26 @@
 import { setIn, getIn } from 'final-form'
 import create from 'zustand'
-import { devtools } from 'zustand/middleware'
+
 const inititalState = {
     errors: {},
     warnings: {},
 }
 
-export const useEntryFormStore = create(
-    devtools((set, get) => ({
-        ...inititalState,
-        setErrors: (errors) => set({ errors: errors ?? {} }),
-        getErrors: () => get().errors,
-        getNumberOfErrors: () => countLeaves(get().getErrors()),
-        getWarnings: () => get().warnings,
-        getWarning: (fieldname) => getIn(get().getWarnings(), fieldname),
-        setWarning: (fieldname, warning) => {
-            const warnings = get().getWarnings() || {}
-            const newWarnings = setIn(warnings, fieldname, warning)
-            set({ warnings: newWarnings })
-        },
-    }))
-)
+export const useEntryFormStore = create((set, get) => ({
+    ...inititalState,
+    setErrors: (errors) => set({ errors: errors ?? {} }),
+    getErrors: () => get().errors,
+    getNumberOfErrors: () => countLeaves(get().getErrors()),
+    getWarnings: () => get().warnings,
+    getWarning: (fieldname) => getIn(get().getWarnings(), fieldname),
+    setWarning: (fieldname, warning) => {
+        const warnings = get().getWarnings()
+        // setIn from final-form is used to create the same structure as errors
+        const newWarnings = setIn(warnings, fieldname, warning)
+        set({ warnings: newWarnings })
+    },
+    // could add getNumberOfWarnings if needed
+}))
 
 // errors object is the same shape as form-Values
 // eg. { [dataElementId] : {

--- a/src/shared/stores/entry-form-store.js
+++ b/src/shared/stores/entry-form-store.js
@@ -1,15 +1,26 @@
+import { setIn, getIn } from 'final-form'
 import create from 'zustand'
-
+import { devtools } from 'zustand/middleware'
 const inititalState = {
     errors: {},
+    warnings: {},
 }
 
-export const useEntryFormStore = create((set, get) => ({
-    ...inititalState,
-    setErrors: (errors) => set({ errors: errors ?? {} }),
-    getErrors: () => get().errors,
-    getNumberOfErrors: () => countLeaves(get().getErrors()),
-}))
+export const useEntryFormStore = create(
+    devtools((set, get) => ({
+        ...inititalState,
+        setErrors: (errors) => set({ errors: errors ?? {} }),
+        getErrors: () => get().errors,
+        getNumberOfErrors: () => countLeaves(get().getErrors()),
+        getWarnings: () => get().warnings,
+        getWarning: (fieldname) => getIn(get().getWarnings(), fieldname),
+        setWarning: (fieldname, warning) => {
+            const warnings = get().getWarnings() || {}
+            const newWarnings = setIn(warnings, fieldname, warning)
+            set({ warnings: newWarnings })
+        },
+    }))
+)
 
 // errors object is the same shape as form-Values
 // eg. { [dataElementId] : {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16284

Requested by Olav on slack. Previously min-max limits were implemented as "hard" limits, and thus the values would not be saved if the value was outside of the limit.

Context from Olav:
> I think this is problematic and should be changed:
min-max are generally defined as some statistical thresholds, so we have to expect that correct values could be outside the thresholds from time to time
data is typically entered from a paper form. It’s good that suspcious values are flagged, but it’s problematic if the data entry user is not able to enter “official” numbers written on the reporting forms
its inconsistent with how validation rules work: flagging issues, but allowing them to be saved
it looks like if a value has previously been entered in a cell, and it’s overwritten with a value outside the min/max thresholds, the old value is never removed from the database which can be misleading

I've now implemented `warnings` as a concept. `FinalForm` does not have an internal concept of "warnings" - validations are either an error that prevents saving - or no error. I've thus implemented a concept of "warnings". They're run in the `FinalForm`-validate function to keep the same behaviour and lifecycle as normal validations , but they do not influence the result. Since we already have a `zustand` store that stores the errors of the form (for sharing outside of form-context), I've implemented a similar structure for warnings as for errors. Using the exact same way as errors are used internally in FinalForm (with `getIn` and `setIn`). We can thus leverage this the exact same way as we do with errors - but currently they're only used for styling - and maybe later we could aggregate the warnings as we do with errors in the bottom-bar. 
