### PR TITLE
fix: prevent unnecessary renders when form has errors

### DIFF
--- a/src/data-workspace/entry-form.js
+++ b/src/data-workspace/entry-form.js
@@ -68,8 +68,12 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
     )
 })
 
-/*  Used to sync store with errors from form
-    In its own component to prevent unecessarily re-renders in the tree */
+/**
+ * Used to sync global store with errors from final-form.
+ * Because of the `errors` subscription in `useFormState`, this re-renders
+ * on every form input change if there is an error in the form. Therefore, this
+ * has its own component to prevent unnecessary re-renders below it in the tree
+ */
 const EntryFormErrorSpy = () => {
     const setFormErrors = useEntryFormStore((state) => state.setErrors)
 

--- a/src/data-workspace/entry-form.js
+++ b/src/data-workspace/entry-form.js
@@ -45,16 +45,6 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
         lockStatus: { state: lockState },
     } = useLockedContext()
     const formType = dataSet.formType
-    const setFormErrors = useEntryFormStore((state) => state.setErrors)
-
-    useFormState({
-        onChange: (formState) => {
-            setFormErrors(formState.errors)
-        },
-        subscription: {
-            errors: true,
-        },
-    })
 
     const Component = formTypeToComponent[formType]
 
@@ -72,11 +62,27 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
                     formType={formType}
                 />
             )}
-
+            <EntryFormErrorSpy />
             <Component dataSet={dataSet} globalFilterText={globalFilterText} />
         </>
     )
 })
+
+/*  Used to sync store with errors from form
+    In its own component to prevent unecessarily re-renders in the tree */
+const EntryFormErrorSpy = () => {
+    const setFormErrors = useEntryFormStore((state) => state.setErrors)
+
+    useFormState({
+        onChange: (formState) => {
+            setFormErrors(formState.errors)
+        },
+        subscription: {
+            errors: true,
+        },
+    })
+    return null
+}
 
 EntryForm.propTypes = {
     dataSet: PropTypes.shape({


### PR DESCRIPTION
While working on https://github.com/dhis2/aggregate-data-entry-app/pull/357 , I noticed the entire form was being re-rendered on each input. We've spent quite a lot of time to optimize this, but I realized it only happened when the form contained an error. The culprit was the logic to keep the zustand-store up to date with the form-errors. I've now moved this to its own component, so the hook won't re-render the entire form. 



Before: 


https://github.com/dhis2/aggregate-data-entry-app/assets/13852438/16cd515e-11a8-4693-b457-c8b36f27ecc0


After:

https://github.com/dhis2/aggregate-data-entry-app/assets/13852438/3e314895-5a0d-4394-8fde-b7e38332ed00



