### PR TITLE
chore(report-portal): run reports only when env is setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,34 @@
+const reportPortalConfig = [
+    '@reportportal/agent-js-jest',
+    {
+        apiKey: process.env.REPORTPORTAL_API_KEY,
+        endpoint: process.env.REPORTPORTAL_ENDPOINT,
+        project: process.env.REPORTPORTAL_PROJECT,
+        launch: 'aggregate_data_entry_app_master',
+        attributes: [
+            {
+                key: 'version',
+                value: 'master',
+            },
+            {
+                key: 'app_name',
+                value: 'aggregate_data_entry_app',
+            },
+            {
+                key: 'test_level',
+                value: 'unit/integration',
+            },
+        ],
+        description: '',
+        debug: true,
+    },
+]
+
+const isReportPortalSetup =
+    process.env.REPORTPORTAL_API_KEY !== undefined &&
+    process.env.REPORTPORTAL_ENDPOINT !== undefined &&
+    process.env.REPORTPORTAL_PROJECT !== undefined
+
 module.exports = {
     setupFilesAfterEnv: ['<rootDir>/src/test-utils/setup-tests.js'],
     collectCoverageFrom: ['src/**/*.{js,jsx}'],
@@ -12,30 +43,6 @@ module.exports = {
     testRunner: 'jest-circus/runner',
     reporters: [
         'default',
-        [
-            '@reportportal/agent-js-jest',
-            {
-                apiKey: process.env.REPORTPORTAL_API_KEY,
-                endpoint: process.env.REPORTPORTAL_ENDPOINT,
-                project: process.env.REPORTPORTAL_PROJECT,
-                launch: 'aggregate_data_entry_app_master',
-                attributes: [
-                    {
-                        key: 'version',
-                        value: 'master',
-                    },
-                    {
-                        key: 'app_name',
-                        value: 'aggregate_data_entry_app',
-                    },
-                    {
-                        key: 'test_level',
-                        value: 'unit/integration',
-                    },
-                ],
-                description: '',
-                debug: true,
-            },
-        ],
+        ...(isReportPortalSetup ? [reportPortalConfig] : []),
     ],
 }


### PR DESCRIPTION
After report-portal was added, it was run even if the required environment-variables wasn't configured. This causes a lot of verbose logging and error-messages in the console.

Not sure if this is the best way, but I couldn't find any native way to do this in `agent-js-jest`. I'm a bit surprised the tool is actually running even if these variables are not defined.
We might want a different `jest.config` for CI and local testing instead?

