### PR TITLE
fix(DHIS2-17002): accept 'u' html tag instead of 'underline'

### DIFF
--- a/src/data-workspace/section-form/section-description.js
+++ b/src/data-workspace/section-form/section-description.js
@@ -8,7 +8,7 @@ export const SectionDescription = ({ children }) => {
         return null
     }
     const html = DOMPurify.sanitize(children, {
-        ALLOWED_TAGS: ['a', 'b', 'strong', 'underline'],
+        ALLOWED_TAGS: ['a', 'b', 'strong', 'u', 'em'],
     })
 
     return (


### PR DESCRIPTION
`underline` html tag is [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u), and we should accept `u` instead for text before and after.

Documentation updated in https://github.com/dhis2/dhis2-docs/pull/1366 

 fixes bug related to https://dhis2.atlassian.net/browse/DHIS2-17002

## Screenshots

![image](https://github.com/dhis2/aggregate-data-entry-app/assets/1014725/85baa5b8-9757-4af9-8163-263e2fa016fd)

![image](https://github.com/dhis2/aggregate-data-entry-app/assets/1014725/62a58869-17d1-4750-815d-b1efc6771264)
