### PR TITLE
fix(section-form): prevent crash when displayOptions are not present

### DIFF
--- a/src/data-workspace/section-form/displayOptions.js
+++ b/src/data-workspace/section-form/displayOptions.js
@@ -1,0 +1,25 @@
+const defaultDisplayOptions = {
+    beforeSectionText: '',
+    pivotMode: 'n/a',
+    afterSectionText: '',
+    pivotCategory: null,
+}
+export const getDisplayOptions = (section) => {
+    if (!section) {
+        return defaultDisplayOptions
+    }
+
+    try {
+        const { displayOptions: displayOptionString } = section
+
+        const displayOptions = JSON.parse(displayOptionString)
+        return displayOptions
+    } catch (e) {
+        // console.log(`Failed to parse displayOptions for section ${section?.id}`)
+        console.error(
+            `Failed to parse displayOptions for section ${section?.displayName}(${section?.id})`,
+            e
+        )
+        return defaultDisplayOptions
+    }
+}

--- a/src/data-workspace/section-form/displayOptions.js
+++ b/src/data-workspace/section-form/displayOptions.js
@@ -12,10 +12,8 @@ export const getDisplayOptions = (section) => {
     try {
         const { displayOptions: displayOptionString } = section
 
-        const displayOptions = JSON.parse(displayOptionString)
-        return displayOptions
+        return JSON.parse(displayOptionString)
     } catch (e) {
-        // console.log(`Failed to parse displayOptions for section ${section?.id}`)
         console.error(
             `Failed to parse displayOptions for section ${section?.displayName}(${section?.id})`,
             e

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -15,6 +15,7 @@ import { CategoryComboTableBody } from '../category-combo-table-body/index.js'
 import { PivotedCategoryComboTableBody } from '../category-combo-table-body-pivoted/index.js'
 import { getFieldId } from '../get-field-id.js'
 import { IndicatorsTableBody } from '../indicators-table-body/indicators-table-body.js'
+import { getDisplayOptions } from './displayOptions.js'
 import { SectionDescription } from './section-description.js'
 import styles from './section.module.css'
 
@@ -64,14 +65,13 @@ export function SectionFormSection({ section, dataSetId, globalFilterText }) {
     const filterInputId = `filter-input-${section.id}`
     const headerCellStyles = classNames(styles.headerCell, styles.hideForPrint)
 
-    const { displayOptions: displayOptionString } = section
-    const displayOptions = JSON.parse(displayOptionString)
+    const displayOptions = getDisplayOptions(section)
 
     const isPivotMode =
-        displayOptions.pivotMode === 'move_categories' ||
-        displayOptions.pivotMode === 'pivot'
+        displayOptions?.pivotMode === 'move_categories' ||
+        displayOptions?.pivotMode === 'pivot'
 
-    const TableComponet = isPivotMode
+    const TableComponent = isPivotMode
         ? PivotedCategoryComboTableBody
         : CategoryComboTableBody
 
@@ -129,7 +129,7 @@ export function SectionFormSection({ section, dataSetId, globalFilterText }) {
                 </TableHead>
                 {groupedDataElements.map(
                     ({ categoryCombo, dataElements }, i) => (
-                        <TableComponet
+                        <TableComponent
                             key={i} //if disableDataElementAutoGroup then duplicate catCombo-ids, so have to use index
                             categoryCombo={categoryCombo}
                             dataElements={dataElements}


### PR DESCRIPTION
Fixes a bug where the app would crash if used on a server version where `section.displayOptions` are not present. 
We could've just checked for the presence before parsing, but I wrapped `JSON.parse` in a try-catch, because `displayOptions` is just an arbitrary string - so it could fail in various ways.

We also should introduce some error-boundaries to the app, so the entire app doesn't crash on errors like this. 