### PR TITLE
feat: add vertical tab rendering of sections in a data set

### DIFF
--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -1,4 +1,5 @@
 import { Tab, TabBar } from '@dhis2/ui'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useSectionFilter } from '../../shared/index.js'
@@ -11,12 +12,17 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
         ? dataSet.sections.filter((s) => s.id === sectionId)
         : dataSet.sections
 
+    const { displayOptions: displayOptionString } = dataSet
+    const displayOptions =
+        displayOptionString && JSON.parse(displayOptionString)
+
     if (dataSet.renderAsTabs) {
         return (
             <TabbedSectionForm
                 globalFilterText={globalFilterText}
                 sections={dataSet.sections}
                 dataSetId={dataSet.id}
+                direction={displayOptions?.tabsDirection}
             />
         )
     }
@@ -37,6 +43,9 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
 
 SectionForm.propTypes = {
     dataSet: PropTypes.shape({
+        displayOptions: PropTypes.shape({
+            tabsDirection: PropTypes.oneOf(['vertical', 'horizontal']),
+        }),
         id: PropTypes.string,
         renderAsTabs: PropTypes.bool,
         sections: PropTypes.arrayOf(
@@ -54,7 +63,12 @@ SectionForm.propTypes = {
     globalFilterText: PropTypes.string,
 }
 
-const TabbedSectionForm = ({ dataSetId, sections, globalFilterText }) => {
+const TabbedSectionForm = ({
+    dataSetId,
+    sections,
+    globalFilterText,
+    direction,
+}) => {
     const [sectionId, setSelectedId] = useSectionFilter()
 
     const section = sectionId
@@ -62,7 +76,11 @@ const TabbedSectionForm = ({ dataSetId, sections, globalFilterText }) => {
         : sections[0]
 
     return (
-        <div>
+        <div
+            className={cx(styles.sectionTabWrapper, {
+                [styles.verticalSectionTabWrapper]: direction === 'vertical',
+            })}
+        >
             <TabBar className={styles.sectionTab}>
                 {sections.map((s) => (
                     <Tab
@@ -87,6 +105,7 @@ const TabbedSectionForm = ({ dataSetId, sections, globalFilterText }) => {
 
 TabbedSectionForm.propTypes = {
     dataSetId: PropTypes.string,
+    direction: PropTypes.oneOf(['vertical', 'horizontal']),
     globalFilterText: PropTypes.string,
     sections: PropTypes.arrayOf(
         PropTypes.shape({

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -65,6 +65,25 @@
 
 .sectionTab {
     margin-bottom: 8px;
+
+}
+
+.verticalSectionTabWrapper .sectionTab div{
+    flex-direction: column;
+}
+
+.sectionTab button{
+    align-self: stretch;
+}
+
+.sectionTabWrapper{
+    display: flex;
+    gap: 6px;
+    flex-direction: column;
+}
+
+.verticalSectionTabWrapper{
+    flex-direction: row;
 }
 
 @media print {


### PR DESCRIPTION
Implements [DHIS2-17506](https://dhis2.atlassian.net/browse/DHIS2-17506).
This PR switched the direction of a dataset section tabs if the user has configures the dataset this way (in separate PR). 

### Implementation details

The displayOptions was added as a JSON type in the BE to allow us flexibility to add more options without updating the back-end, similarly to what was done for sections. See discussion in https://github.com/dhis2/dhis2-core/pull/16562 


### Background

We are aiming to add more form configuration options as part of an initiative to provide configurations natively to data entry forms to reduce the necessity for custom forms. Users are currently building custom forms as a workaround for shortcomings of the configuration options (ability to transpose, or customise a cell design) or implementation (such to avoid issues with RTL issues).

This is [an RFC](https://dhis2.atlassian.net/wiki/spaces/SOFTWARE/pages/121995265/Form+configuration+RFC) that describes the approach and the priorities for form configuration options. This is based on a [thorough investigation](https://docs.google.com/presentation/d/1pSeFoF91HDYNeL88GghKLvj3wpYf0qUCdhkKXklB2MY/edit#slide=id.g2462c2dd6c9_0_53) by the functional design team for custom form use cases in real-life implementations. Based on that investigation, the ability to show section tabs vertically were one of the main reasons people choose to go the custom forms route so we're tackling these first.


### UI

The ui is still work in progress but it will look like similar to this: 

https://github.com/dhis2/dhis2-core/assets/5418349/06c571eb-916a-4714-8c0e-a0a4ba8c7515


### Related PRs: 

https://github.com/dhis2/dhis2-core/pull/17891