### PR TITLE
feat: make data sets sections collapsable

### DIFF
--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.js
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.js
@@ -24,13 +24,14 @@ export const PivotedCategoryComboTableBody = React.memo(
         categoryCombo,
         dataElements,
         greyedFields,
-        /* 
+        /*
         filterText,
         globalFilterText,
         maxColumnsInSection,
         renderRowTotals,
         renderColumnTotals,*/
         displayOptions,
+        collapsed,
     }) {
         const { data: metadata } = useMetadata()
 
@@ -68,7 +69,12 @@ export const PivotedCategoryComboTableBody = React.memo(
             <>
                 {rowsMatrix.map((row, id /** todo: find suitable id */) => {
                     return (
-                        <TableRow key={id}>
+                        <TableRow
+                            key={id}
+                            className={classNames({
+                                [styles.sectionRowCollapsed]: collapsed,
+                            })}
+                        >
                             {row.map((fieldInRow) => {
                                 if (
                                     fieldInRow.type === 'columnHeader' ||
@@ -150,6 +156,7 @@ PivotedCategoryComboTableBody.propTypes = {
     categoryCombo: PropTypes.shape({
         id: PropTypes.string.isRequired,
     }),
+    collapsed: PropTypes.bool,
     dataElements: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string.isRequired,

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.js
@@ -1,8 +1,8 @@
-import { TableBody, TableRow, TableCell } from '@dhis2/ui'
+import { TableBody, TableCell, TableRow } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
-import { useMetadata, selectors } from '../../shared/index.js'
+import { selectors, useMetadata } from '../../shared/index.js'
 import { DataEntryCell, DataEntryField } from '../data-entry-cell/index.js'
 import { getFieldId } from '../get-field-id.js'
 import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.js'
@@ -21,6 +21,7 @@ export const CategoryComboTableBody = React.memo(
         maxColumnsInSection,
         renderRowTotals,
         renderColumnTotals,
+        collapsed,
     }) {
         const { data: metadata } = useMetadata()
 
@@ -59,7 +60,11 @@ export const CategoryComboTableBody = React.memo(
         const hiddenItemsCount = filteredDeIds.size
 
         return (
-            <TableBody>
+            <TableBody
+                className={cx({
+                    [styles.sectionRowCollapsed]: collapsed,
+                })}
+            >
                 <CategoryComboTableBodyHeader
                     categoryOptionCombos={sortedCOCs}
                     categories={categories}
@@ -128,6 +133,7 @@ CategoryComboTableBody.propTypes = {
     categoryCombo: PropTypes.shape({
         id: PropTypes.string.isRequired,
     }),
+    collapsed: PropTypes.bool,
     dataElements: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string.isRequired,

--- a/src/data-workspace/section-form/displayOptions.js
+++ b/src/data-workspace/section-form/displayOptions.js
@@ -11,7 +11,6 @@ export const getDisplayOptions = (section) => {
 
     try {
         const { displayOptions: displayOptionString } = section
-
         return JSON.parse(displayOptionString)
     } catch (e) {
         console.error(

--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -3,7 +3,6 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useSectionFilter } from '../../shared/index.js'
-import { useFeature } from '../use-feature.js'
 import { SectionFormSection } from './section.js'
 import styles from './section.module.css'
 
@@ -24,7 +23,6 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
 
     const { displayOptions: displayOptionString } = dataSet
     const displayOptions = parseDisplayOptions(displayOptionString)
-    const featureToggleCollapsible = useFeature('collapsible')
 
     if (dataSet.renderAsTabs) {
         return (
@@ -45,7 +43,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
                     dataSetId={dataSet.id}
                     key={s.id}
                     globalFilterText={globalFilterText}
-                    collapsible={featureToggleCollapsible}
+                    collapsible
                 />
             ))}
         </>

--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -43,6 +43,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
                     dataSetId={dataSet.id}
                     key={s.id}
                     globalFilterText={globalFilterText}
+                    collapsible
                 />
             ))}
         </>

--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -31,6 +31,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
                 sections={dataSet.sections}
                 dataSetId={dataSet.id}
                 direction={displayOptions?.tabsDirection}
+                collapsible={displayOptions?.collapsibleSections}
             />
         )
     }
@@ -43,7 +44,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
                     dataSetId={dataSet.id}
                     key={s.id}
                     globalFilterText={globalFilterText}
-                    collapsible
+                    collapsible={displayOptions?.collapsibleSections}
                 />
             ))}
         </>
@@ -53,6 +54,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
 SectionForm.propTypes = {
     dataSet: PropTypes.shape({
         displayOptions: PropTypes.shape({
+            collapsibleSections: PropTypes.bool,
             tabsDirection: PropTypes.oneOf(['vertical', 'horizontal']),
         }),
         id: PropTypes.string,

--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useSectionFilter } from '../../shared/index.js'
+import { useFeature } from '../use-feature.js'
 import { SectionFormSection } from './section.js'
 import styles from './section.module.css'
 
@@ -23,6 +24,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
 
     const { displayOptions: displayOptionString } = dataSet
     const displayOptions = parseDisplayOptions(displayOptionString)
+    const featureToggleCollapsible = useFeature('collapsible')
 
     if (dataSet.renderAsTabs) {
         return (
@@ -31,7 +33,6 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
                 sections={dataSet.sections}
                 dataSetId={dataSet.id}
                 direction={displayOptions?.tabsDirection}
-                collapsible={displayOptions?.collapsibleSections}
             />
         )
     }
@@ -44,7 +45,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
                     dataSetId={dataSet.id}
                     key={s.id}
                     globalFilterText={globalFilterText}
-                    collapsible={displayOptions?.collapsibleSections}
+                    collapsible={featureToggleCollapsible}
                 />
             ))}
         </>
@@ -53,10 +54,7 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
 
 SectionForm.propTypes = {
     dataSet: PropTypes.shape({
-        displayOptions: PropTypes.shape({
-            collapsibleSections: PropTypes.bool,
-            tabsDirection: PropTypes.oneOf(['vertical', 'horizontal']),
-        }),
+        displayOptions: PropTypes.string,
         id: PropTypes.string,
         renderAsTabs: PropTypes.bool,
         sections: PropTypes.arrayOf(

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -1,8 +1,8 @@
 import i18n from '@dhis2/d2-i18n'
 import {
     colors,
-    IconChevronDown24,
-    IconChevronUp24,
+    IconChevronDown16,
+    IconChevronUp16,
     IconFilter16,
     Table,
     TableCellHead,
@@ -106,6 +106,19 @@ export function SectionFormSection({
                             className={styles.headerCell}
                         >
                             <div className={styles.labelWrapper}>
+                                <div
+                                    className={styles.collapseIcon}
+                                    tabIndex={collapsible ? 0 : -1}
+                                    onClick={onSectionHeadClicked}
+                                    onKeyDown={onSectionHeadEntered}
+                                >
+                                    {collapsible &&
+                                        (showSectionContent ? (
+                                            <IconChevronUp16 color="white" />
+                                        ) : (
+                                            <IconChevronDown16 color="white" />
+                                        ))}
+                                </div>
                                 <div>
                                     <div className={styles.title}>
                                         {section.displayName}
@@ -116,19 +129,6 @@ export function SectionFormSection({
                                                 'Placeholder section description'}
                                         </div>
                                     )}
-                                </div>
-                                <div
-                                    className={styles.collapseIcon}
-                                    tabIndex={collapsible ? 0 : -1}
-                                    onClick={onSectionHeadClicked}
-                                    onKeyDown={onSectionHeadEntered}
-                                >
-                                    {collapsible &&
-                                        (showSectionContent ? (
-                                            <IconChevronUp24 color="white" />
-                                        ) : (
-                                            <IconChevronDown24 color="white" />
-                                        ))}
                                 </div>
                             </div>
                         </TableCellHead>

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -114,9 +114,9 @@ export function SectionFormSection({
                                 >
                                     {collapsible &&
                                         (showSectionContent ? (
-                                            <IconChevronUp16 color="white" />
+                                            <IconChevronUp16 color="var(--colors-white)" />
                                         ) : (
-                                            <IconChevronDown16 color="white" />
+                                            <IconChevronDown16 color="var(--colors-white)" />
                                         ))}
                                 </div>
                                 <div>
@@ -162,23 +162,23 @@ export function SectionFormSection({
                         </TableRowHead>
                     )}
                 </TableHead>
-                {showSectionContent &&
-                    groupedDataElements.map(
-                        ({ categoryCombo, dataElements }, i) => (
-                            <TableComponent
-                                key={i} //if disableDataElementAutoGroup then duplicate catCombo-ids, so have to use index
-                                categoryCombo={categoryCombo}
-                                dataElements={dataElements}
-                                filterText={filterText}
-                                globalFilterText={globalFilterText}
-                                maxColumnsInSection={maxColumnsInSection}
-                                renderRowTotals={section.showRowTotals}
-                                renderColumnTotals={section.showColumnTotals}
-                                greyedFields={greyedFields}
-                                displayOptions={displayOptions}
-                            />
-                        )
-                    )}
+                {groupedDataElements.map(
+                    ({ categoryCombo, dataElements }, i) => (
+                        <TableComponent
+                            key={i} //if disableDataElementAutoGroup then duplicate catCombo-ids, so have to use index
+                            categoryCombo={categoryCombo}
+                            dataElements={dataElements}
+                            filterText={filterText}
+                            globalFilterText={globalFilterText}
+                            maxColumnsInSection={maxColumnsInSection}
+                            renderRowTotals={section.showRowTotals}
+                            renderColumnTotals={section.showColumnTotals}
+                            greyedFields={greyedFields}
+                            displayOptions={displayOptions}
+                            collapsed={!showSectionContent}
+                        />
+                    )
+                )}
                 {indicators.length > 0 && showSectionContent && (
                     <IndicatorsTableBody
                         indicators={indicators}

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -1,6 +1,8 @@
 import i18n from '@dhis2/d2-i18n'
 import {
     colors,
+    IconChevronDown24,
+    IconChevronUp24,
     IconFilter16,
     Table,
     TableCellHead,
@@ -8,10 +10,8 @@ import {
     TableRowHead,
 } from '@dhis2/ui'
 import classNames from 'classnames'
-import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo, useState } from 'react'
-import MenuSelect from '../../context-selection/menu-select/menu-select'
 import { useMetadata, selectors } from '../../shared/index.js'
 import { CategoryComboTableBody } from '../category-combo-table-body/index.js'
 import { PivotedCategoryComboTableBody } from '../category-combo-table-body-pivoted/index.js'
@@ -105,24 +105,31 @@ export function SectionFormSection({
                             colSpan="100%"
                             className={styles.headerCell}
                         >
-                            <div
-                                className={cx(styles.labelWrapper, {
-                                    [styles.labelWrapperCollapsible]:
-                                        collapsible,
-                                })}
-                                tabIndex={collapsible ? 0 : -1}
-                                onClick={onSectionHeadClicked}
-                                onKeyDown={onSectionHeadEntered}
-                            >
-                                <div className={styles.title}>
-                                    {section.displayName}
-                                </div>
-                                {section.description && (
-                                    <div className={styles.description}>
-                                        {section.description ||
-                                            'Placeholder section description'}
+                            <div className={styles.labelWrapper}>
+                                <div>
+                                    <div className={styles.title}>
+                                        {section.displayName}
                                     </div>
-                                )}
+                                    {section.description && (
+                                        <div className={styles.description}>
+                                            {section.description ||
+                                                'Placeholder section description'}
+                                        </div>
+                                    )}
+                                </div>
+                                <div
+                                    className={styles.collapseIcon}
+                                    tabIndex={collapsible ? 0 : -1}
+                                    onClick={onSectionHeadClicked}
+                                    onKeyDown={onSectionHeadEntered}
+                                >
+                                    {collapsible &&
+                                        (showSectionContent ? (
+                                            <IconChevronUp24 color="white" />
+                                        ) : (
+                                            <IconChevronDown24 color="white" />
+                                        ))}
+                                </div>
                             </div>
                         </TableCellHead>
                     </TableRowHead>

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -24,6 +24,11 @@
     line-height: 20px;
     padding: 4px 8px;
 }
+
+.labelWrapperCollapsible {
+    cursor: pointer;
+}
+
 .title {
     color: var(--colors-grey050);
     font-weight: 400;

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -23,9 +23,12 @@
     background-color: var(--colors-grey800);
     line-height: 20px;
     padding: 4px 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
-.labelWrapperCollapsible {
+.collapseIcon {
     cursor: pointer;
 }
 

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -9,7 +9,8 @@
     .labelWrapper {
         background-color: transparent !important;
     }
-    .title, .description {
+    .title,
+    .description {
         color: black !important;
     }
 }
@@ -24,12 +25,31 @@
     line-height: 20px;
     padding: 4px 8px;
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 4px;
 }
 
 .collapseIcon {
+    margin-inline-start: -4px;
+    padding: var(--spacers-dp4);
+    height: 24px;
+    width: 24px;
+    align-self: flex-start;
+    border-radius: 3px;
     cursor: pointer;
+}
+
+.collapseIcon:hover {
+    background-color: var(--colors-grey900);
+}
+
+.collapseIcon:focus {
+    outline: 3px solid var(--theme-focus);
+}
+
+/* Prevent focus styles when mouse clicking */
+.collapseIcon:focus:not(:focus-visible) {
+    outline: none;
 }
 
 .title {
@@ -73,30 +93,29 @@
 
 .sectionTab {
     margin-bottom: 8px;
-
 }
 
-.verticalSectionTabWrapper .sectionTab div{
+.verticalSectionTabWrapper .sectionTab div {
     flex-direction: column;
 }
 
-.sectionTab button{
+.sectionTab button {
     align-self: stretch;
 }
 
-.sectionTabWrapper{
+.sectionTabWrapper {
     display: flex;
     gap: 6px;
     flex-direction: column;
 }
 
-.verticalSectionTabWrapper{
+.verticalSectionTabWrapper {
     flex-direction: row;
 }
 
 @media print {
     .hideForPrint {
-        composes: hideForPrint from '../../app/app.css'
+        composes: hideForPrint from '../../app/app.css';
     }
 }
 
@@ -104,12 +123,12 @@
 .sectionDescription {
     margin: 12px 4px 8px;
     font-size: 13px;
-    color: var(--colors-grey800)
+    color: var(--colors-grey800);
 }
 
 .sectionDescription :global(a):link,
 .sectionDescription :global(a):visited,
 .sectionDescription :global(a):hover,
 .sectionDescription :global(a):active {
-    color: var(--colors-blue700)
+    color: var(--colors-blue700);
 }

--- a/src/data-workspace/table-body.module.css
+++ b/src/data-workspace/table-body.module.css
@@ -3,13 +3,17 @@
     padding: 8px !important;
     height: auto !important;
     font-size: 13px !important;
-    line-height: 15px !important; 
+    line-height: 15px !important;
 }
 
 .tableHeader {
     composes: cellBase;
     background-color: var(--colors-grey200);
     font-weight: 500;
+}
+
+.sectionRowCollapsed{
+    visibility: collapse;
 }
 
 .categoryNameHeader {

--- a/src/data-workspace/use-feature.js
+++ b/src/data-workspace/use-feature.js
@@ -1,8 +1,0 @@
-import { StringParam, useQueryParam } from 'use-query-params'
-
-export function useFeature(feature) {
-    const [allFeatures] = useQueryParam('features', StringParam)
-    const features = allFeatures?.split(',')
-
-    return !!features?.includes(feature)
-}

--- a/src/data-workspace/use-feature.js
+++ b/src/data-workspace/use-feature.js
@@ -1,0 +1,8 @@
+import { StringParam, useQueryParam } from 'use-query-params'
+
+export function useFeature(feature) {
+    const [allFeatures] = useQueryParam('features', StringParam)
+    const features = allFeatures?.split(',')
+
+    return !!features?.includes(feature)
+}


### PR DESCRIPTION
Implements [DHIS2-17507](https://dhis2.atlassian.net/browse/DHIS2-17507).
This PR allows for sections of a data set to be collapsible

### Implementation details

We have decided that all sections should be collapsible by default, and this for now will not be a setting in the maintenance app 

Collapsible is applied only when the  " render as tabs" option is not turned on for the specific dataset

### Background

We are aiming to add more form configuration options as part of an initiative to provide configurations natively to data entry forms to reduce the necessity for custom forms. Users are currently building custom forms as a workaround for shortcomings of the configuration options (ability to transpose, or customise a cell design) or implementation (such to avoid issues with RTL issues).

This is [an RFC](https://dhis2.atlassian.net/wiki/spaces/SOFTWARE/pages/121995265/Form+configuration+RFC) that describes the approach and the priorities for form configuration options. This is based on a [thorough investigation](https://docs.google.com/presentation/d/1pSeFoF91HDYNeL88GghKLvj3wpYf0qUCdhkKXklB2MY/edit#slide=id.g2462c2dd6c9_0_53) by the functional design team for custom form use cases in real-life implementations. Based on that investigation, the ability to collapse sections were one of the main reasons people choose to go the custom forms route so we're tackling these first.

### UI

This is a video of the feature: 

https://github.com/user-attachments/assets/0ff743da-9ae0-4ab2-9232-0a670cd62809



[DHIS2-17507]: https://dhis2.atlassian.net/browse/DHIS2-17507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ