### PR TITLE
fix: handle java language format [DHIS2-18031]

### DIFF
--- a/src/shared/use-user-info/use-user-info.js
+++ b/src/shared/use-user-info/use-user-info.js
@@ -8,8 +8,25 @@ const queryOpts = {
     staleTime: 24 * 60 * 60 * 1000,
 }
 
+const parseLocale = (unparsedLocale) => {
+    if (typeof unparsedLocale !== 'string') {
+        return 'en'
+    }
+
+    // while script is possible in DHIS2 locales, it is not supported in underlying multi-calendar-dates logic
+    const [lng, region] = unparsedLocale?.replaceAll('_', '-').split('-')
+
+    return region ? `${lng}-${region}` : lng
+}
+
 export const useUserInfo = () => {
     const userInfoQuery = useQuery(queryKey, queryOpts)
+    // this maps java format locales like `pt_BR` to JS style `pt-BR`
+    if (userInfoQuery?.data?.settings?.keyUiLocale) {
+        userInfoQuery.data.settings.keyUiLocale = parseLocale(
+            userInfoQuery.data.settings.keyUiLocale
+        )
+    }
     return userInfoQuery
 }
 

--- a/src/shared/use-user-info/use-user-info.js
+++ b/src/shared/use-user-info/use-user-info.js
@@ -14,7 +14,7 @@ const parseLocale = (unparsedLocale) => {
     }
 
     // while script is possible in DHIS2 locales, it is not supported in underlying multi-calendar-dates logic
-    const [lng, region] = unparsedLocale?.replaceAll('_', '-').split('-')
+    const [lng, region] = unparsedLocale?.replace(/_/g, '-').split('-')
 
     return region ? `${lng}-${region}` : lng
 }

--- a/src/shared/use-user-info/use-user-info.test.js
+++ b/src/shared/use-user-info/use-user-info.test.js
@@ -1,0 +1,92 @@
+import { useQuery } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react-hooks'
+import { useUserInfo } from './use-user-info.js'
+
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: jest.fn(() => ({})),
+}))
+
+describe('useUserInfo', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('returns value without modification if keyUiLocale not in data', () => {
+        const mockedValue = {
+            isLoading: false,
+            data: { settings: { keyAnalysisDisplayProperty: false } },
+        }
+        useQuery.mockReturnValue(mockedValue)
+        const { result } = renderHook(() => useUserInfo())
+        expect(result.current).toEqual(mockedValue)
+    })
+
+    it('returns value without modification if keyUiLocale that only contains language', () => {
+        const mockedValue = {
+            isLoading: false,
+            data: {
+                settings: {
+                    keyUiLocale: 'ar',
+                    keyAnalysisDisplayProperty: false,
+                },
+            },
+        }
+        useQuery.mockReturnValue(mockedValue)
+        const { result } = renderHook(() => useUserInfo())
+        expect(result.current).toEqual(mockedValue)
+    })
+
+    it('fixes keyUiLocale that contains _', () => {
+        const mockedValue = {
+            isLoading: false,
+            data: {
+                settings: {
+                    keyUiLocale: 'pt_BR',
+                    keyAnalysisDisplayProperty: false,
+                },
+            },
+        }
+        const fixedValue = { ...mockedValue }
+        fixedValue.data.settings.keyUiLocale = 'pt-BR'
+
+        useQuery.mockReturnValue(mockedValue)
+        const { result } = renderHook(() => useUserInfo())
+        expect(result.current).toEqual(fixedValue)
+    })
+
+    it('removes script for keyUiLocale that includes script', () => {
+        const mockedValue = {
+            isLoading: false,
+            data: {
+                settings: {
+                    keyUiLocale: 'uz-UZ-Cyrl',
+                    keyAnalysisDisplayProperty: false,
+                },
+            },
+        }
+        const fixedValue = { ...mockedValue }
+        fixedValue.data.settings.keyUiLocale = 'uz-UZ'
+
+        useQuery.mockReturnValue(mockedValue)
+        const { result } = renderHook(() => useUserInfo())
+        expect(result.current).toEqual(fixedValue)
+    })
+
+    it('defaults to English if UI returns invalid type for keyUiLocale', () => {
+        const mockedValue = {
+            isLoading: false,
+            data: {
+                settings: {
+                    keyUiLocale: 42,
+                    keyAnalysisDisplayProperty: false,
+                },
+            },
+        }
+        const fixedValue = { ...mockedValue }
+        fixedValue.data.settings.keyUiLocale = 'en'
+
+        useQuery.mockReturnValue(mockedValue)
+        const { result } = renderHook(() => useUserInfo())
+        expect(result.current).toEqual(fixedValue)
+    })
+})


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18031

### Background 
This ticket converts keyUiLocale from the Java format (e.g. pt_BR) to the ISO format (pt-BR). The app is currently crashing because the functions to generate periods within multi-calendar-dates fails when passed a locale string.

_Note:_ We also have two UI locales that include script (`uz_UZ_Cyrl`, `uz_UZ_Latn`), which in valid ISO format would be (`uz-Cyrl-UZ`, `uz-Latn-UZ`), but these cause problems in multi-calendar-dates even when passed in the proper ISO format, so for not I am just removing the potential script tag and converting to `uz-UZ` (probably need a follow up for multi-calendar-dates to handle languages with scripts) 

**Before**
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/e8e3c831-4108-47ae-b4d2-c70abc4b18c5">


**After** 
<img width="958" alt="image" src="https://github.com/user-attachments/assets/fb34aa2c-df6c-49bd-ba15-d61e4f1a0314">


### Testing
Manual: I have tested with Portuguese (Brazilian), Arabic (Egyptian), English, Portuguese, Arabic, French, and the two varieties of Uzbek

Automated: I have added some tests for the useUserInfo hook to test that the conversion of the language code occurs as expected.