### PR TITLE
feat: add title and subtitle to data sets if set in display options

### DIFF
--- a/src/data-workspace/section-form/sanitized-text.js
+++ b/src/data-workspace/section-form/sanitized-text.js
@@ -1,9 +1,8 @@
 import * as DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styles from './section.module.css'
 
-export const SectionDescription = ({ children }) => {
+export const SanitizedText = ({ children, className }) => {
     if (!children) {
         return null
     }
@@ -12,13 +11,11 @@ export const SectionDescription = ({ children }) => {
     })
 
     return (
-        <div
-            className={styles.sectionDescription}
-            dangerouslySetInnerHTML={{ __html: html }}
-        ></div>
+        <p className={className} dangerouslySetInnerHTML={{ __html: html }}></p>
     )
 }
 
-SectionDescription.propTypes = {
+SanitizedText.propTypes = {
     children: PropTypes.node,
+    className: PropTypes.string,
 }

--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -19,13 +19,14 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
     return (
         <>
             <div
-                className={cx(styles.sectionsCustomerText, {
-                    [styles.textLeft]:
-                        displayOptions.customText?.align === 'left',
+                className={cx(styles.sectionsCustomText, {
+                    [styles.textStartLine]:
+                        displayOptions.customText?.align === 'line-start',
                     [styles.textCenter]:
                         displayOptions.customText?.align === 'center',
-                    [styles.textRight]:
-                        displayOptions.customText?.align === 'right',
+                    [styles.textEndLine]:
+                        !displayOptions.customText ||
+                        displayOptions.customText?.align === 'line-end',
                 })}
             >
                 {displayOptions.customText?.header && (

--- a/src/data-workspace/section-form/section-form.js
+++ b/src/data-workspace/section-form/section-form.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useSectionFilter } from '../../shared/index.js'
 import { getDisplayOptions } from './displayOptions.js'
+import { SanitizedText } from './sanitized-text.js'
 import { SectionFormSection } from './section.js'
 import styles from './section.module.css'
 
@@ -15,28 +16,47 @@ export const SectionForm = ({ dataSet, globalFilterText }) => {
 
     const displayOptions = getDisplayOptions(dataSet)
 
-    if (dataSet.renderAsTabs) {
-        return (
-            <TabbedSectionForm
-                globalFilterText={globalFilterText}
-                sections={dataSet.sections}
-                dataSetId={dataSet.id}
-                direction={displayOptions?.tabsDirection}
-            />
-        )
-    }
-
     return (
         <>
-            {filteredSections.map((s) => (
-                <SectionFormSection
-                    section={s}
-                    dataSetId={dataSet.id}
-                    key={s.id}
+            <div
+                className={cx(styles.sectionsCustomerText, {
+                    [styles.textLeft]:
+                        displayOptions.customText?.align === 'left',
+                    [styles.textCenter]:
+                        displayOptions.customText?.align === 'center',
+                    [styles.textRight]:
+                        displayOptions.customText?.align === 'right',
+                })}
+            >
+                {displayOptions.customText?.header && (
+                    <SanitizedText className={styles.sectionsTitle}>
+                        {displayOptions.customText?.header}
+                    </SanitizedText>
+                )}
+                {displayOptions.customText?.subheader && (
+                    <SanitizedText className={styles.sectionsSubtitle}>
+                        {displayOptions.customText?.subheader}
+                    </SanitizedText>
+                )}
+            </div>
+            {dataSet.renderAsTabs ? (
+                <TabbedSectionForm
                     globalFilterText={globalFilterText}
-                    collapsible
+                    sections={dataSet.sections}
+                    dataSetId={dataSet.id}
+                    direction={displayOptions?.tabsDirection}
                 />
-            ))}
+            ) : (
+                filteredSections.map((s) => (
+                    <SectionFormSection
+                        section={s}
+                        dataSetId={dataSet.id}
+                        key={s.id}
+                        globalFilterText={globalFilterText}
+                        collapsible
+                    />
+                ))
+            )}
         </>
     )
 }

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -18,7 +18,7 @@ import { PivotedCategoryComboTableBody } from '../category-combo-table-body-pivo
 import { getFieldId } from '../get-field-id.js'
 import { IndicatorsTableBody } from '../indicators-table-body/indicators-table-body.js'
 import { getDisplayOptions } from './displayOptions.js'
-import { SectionDescription } from './section-description.js'
+import { SanitizedText } from './sanitized-text.js'
 import styles from './section.module.css'
 
 export function SectionFormSection({
@@ -97,7 +97,9 @@ export function SectionFormSection({
 
     return (
         <div>
-            <SectionDescription>{beforeSectionText}</SectionDescription>
+            <SanitizedText className={styles.sectionDescription}>
+                {beforeSectionText}
+            </SanitizedText>
             <Table className={styles.table} suppressZebraStriping>
                 <TableHead>
                     <TableRowHead>
@@ -189,7 +191,9 @@ export function SectionFormSection({
                     />
                 )}
             </Table>
-            <SectionDescription>{afterSectionText}</SectionDescription>
+            <SanitizedText className={styles.sectionDescription}>
+                {afterSectionText}
+            </SanitizedText>
         </div>
     )
 }

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -91,8 +91,29 @@
     outline: 3px solid var(--theme-focus);
 }
 
+.sectionsTitle {
+    margin: 4px;
+    font-size: 2em;
+}
+.sectionsSubtitle{
+    margin: 2px;
+    font-size: 1.5em;
+}
+.sectionsCustomerText{
+    width: 100%;
+    padding: 16px;
+}
 .sectionTab {
     margin-bottom: 8px;
+}
+.textLeft{
+    text-align: left;
+}
+.textCenter{
+    text-align: center;
+}
+.textRight{
+    text-align: right;
 }
 
 .verticalSectionTabWrapper .sectionTab div {

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -99,21 +99,21 @@
     margin: 2px;
     font-size: 1.5em;
 }
-.sectionsCustomerText{
+.sectionsCustomText{
     width: 100%;
     padding: 16px;
 }
 .sectionTab {
     margin-bottom: 8px;
 }
-.textLeft{
-    text-align: left;
+.textStartLine{
+    text-align: start;
 }
 .textCenter{
     text-align: center;
 }
-.textRight{
-    text-align: right;
+.textEndLine{
+    text-align: end;
 }
 
 .verticalSectionTabWrapper .sectionTab div {


### PR DESCRIPTION
Implements [DHIS2-18129](https://dhis2.atlassian.net/browse//DHIS2-18129).
This PR allows users to add a title/ substitle to datasets

## Implementation details
The displayOptions was added as a JSON type in the BE to allow us flexibility to add more options without updating the back-end. See discussion in https://github.com/dhis2/dhis2-core/pull/16562


## Background
We are aiming to add more form configuration options as part of an initiative to provide configurations natively to data entry forms to reduce the necessity for custom forms. Users are currently building custom forms as a workaround for shortcomings of the configuration options (ability to transpose, or customise a cell design) or implementation (such to avoid issues with RTL issues).

This is [an RFC](https://dhis2.atlassian.net/wiki/spaces/SOFTWARE/pages/121995265/Form+configuration+RFC) that describes the approach and the priorities for form configuration options. This is based on a [thorough investigation](https://docs.google.com/presentation/d/1pSeFoF91HDYNeL88GghKLvj3wpYf0qUCdhkKXklB2MY/edit#slide=id.g2462c2dd6c9_0_53) by the functional design team for custom form use cases in real-life implementations. Based on that investigation, the ability to add custom text to sections were one of the main reasons people choose to go the custom forms route so we're tackling these first.

## Preview
<img width="1147" alt="Screenshot 2024-10-14 at 14 09 01" src="https://github.com/user-attachments/assets/956c5cac-b356-4783-a753-7922897b0dff">
<img width="1158" alt="Screenshot 2024-10-14 at 14 08 43" src="https://github.com/user-attachments/assets/529b1a23-23ff-495c-888e-eab7b30de563">
<img width="1008" alt="Screenshot 2024-10-14 at 14 06 20" src="https://github.com/user-attachments/assets/3622b36f-86e8-47f6-9d5c-6319183dbbc2">


[DHIS2-18129]: https://dhis2.atlassian.net/browse/DHIS2-18129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ