### PR TITLE
feat: when we have multiple sections, default to first section 

### DIFF
--- a/cypress/e2e/context-selection/section-filter/index.js
+++ b/cypress/e2e/context-selection/section-filter/index.js
@@ -124,7 +124,7 @@ Then('that section should be selected', () => {
 
 Then('the "all sections" option should be selected', () => {
     cy.get('[data-test="section-filter-selector"]')
-        .contains('All sections')
+        .contains('Equipment')
         .should('exist')
 })
 

--- a/src/context-selection/section-filter-selector-bar-item/section-filter-selector-bar-item.js
+++ b/src/context-selection/section-filter-selector-bar-item/section-filter-selector-bar-item.js
@@ -28,8 +28,7 @@ export default function SectionFilterSelectorBarItem() {
 
     useEffect(() => {
         const sections = dataSet?.sections
-        // select first section if renderAsTabs === true
-        if (dataSet?.renderAsTabs && !sectionFilter && sections?.length) {
+        if (sectionFilter === undefined && sections?.length) {
             setSectionFilter(sections[0].id)
         }
         // clear out section if it is invalid
@@ -55,9 +54,7 @@ export default function SectionFilterSelectorBarItem() {
 
     const selectableOptions = dataSet?.renderAsTabs
         ? sectionOptions
-        : [{ value: undefined, label: i18n.t('All sections') }].concat(
-              ...sectionOptions
-          )
+        : [...sectionOptions, { value: null, label: i18n.t('All sections') }]
 
     return (
         <div data-test="section-filter-selector">


### PR DESCRIPTION
This Pr is meant to address the performance problems that occur when forms with many fields are rendered.
In this PR, we mitigate the problem by rendering by default only one section. This is a temporary fix until a proper fix will be in place. 
