### PR TITLE
fix: handle compulsory data element operands [DHIS2-17647]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-10-18T12:58:59.146Z\n"
-"PO-Revision-Date: 2024-10-18T12:58:59.146Z\n"
+"POT-Creation-Date: 2024-11-29T16:17:15.582Z\n"
+"PO-Revision-Date: 2024-11-29T16:17:15.582Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -80,6 +80,9 @@ msgstr "Couldn't validate the form. This does not effect form completion!"
 
 msgid "The form can't be completed while invalid"
 msgstr "The form can't be completed while invalid"
+
+msgid "Compulsory fields must be filled out before completing the form"
+msgstr "Compulsory fields must be filled out before completing the form"
 
 msgid "1 comment required"
 msgstr "1 comment required"
@@ -212,6 +215,9 @@ msgstr "Warning, saved"
 
 msgid "Locked, not editable"
 msgstr "Locked, not editable"
+
+msgid "Compulsory field"
+msgstr "Compulsory field"
 
 msgid "Help"
 msgstr "Help"

--- a/src/bottom-bar/complete-button.test.js
+++ b/src/bottom-bar/complete-button.test.js
@@ -1,0 +1,220 @@
+import { waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { useMetadata } from '../shared/metadata/use-metadata.js'
+import { useDataSetId } from '../shared/use-context-selection/use-context-selection.js'
+import { useDataValueSet } from '../shared/use-data-value-set/use-data-value-set.js'
+import { useImperativeValidate } from '../shared/validation/use-imperative-validate.js'
+import { render } from '../test-utils/render.js'
+import CompleteButton from './complete-button.js'
+
+const mockShow = jest.fn()
+const mockSetFormCompletion = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve())
+const mockValidate = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+        commentRequiredViolations: [],
+        validationRuleViolations: [],
+    })
+)
+const mockSetCompleteAttempted = jest.fn()
+const mockIsComplete = jest.fn()
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    useAlert: jest.fn(() => ({
+        show: mockShow,
+    })),
+}))
+
+jest.mock('../shared/use-context-selection/use-context-selection.js', () => ({
+    ...jest.requireActual(
+        '../shared/use-context-selection/use-context-selection.js'
+    ),
+    useDataSetId: jest.fn(),
+}))
+
+jest.mock('../shared/metadata/use-metadata.js', () => ({
+    useMetadata: jest.fn(),
+}))
+
+jest.mock('../shared/validation/use-imperative-validate.js', () => ({
+    useImperativeValidate: jest.fn(),
+}))
+
+jest.mock('../shared/completion/use-set-form-completion-mutation.js', () => ({
+    ...jest.requireActual(
+        '../shared/completion/use-set-form-completion-mutation.js'
+    ),
+    useSetFormCompletionMutation: jest.fn(() => ({
+        mutateAsync: mockSetFormCompletion,
+    })),
+}))
+
+jest.mock('../shared/stores/entry-form-store.js', () => ({
+    ...jest.requireActual('../shared/stores/entry-form-store.js'),
+    useEntryFormStore: jest.fn().mockImplementation((func) => {
+        const state = {
+            setCompleteAttempted: mockSetCompleteAttempted,
+        }
+        return func(state)
+    }),
+}))
+
+jest.mock('../shared/stores/data-value-store.js', () => ({
+    ...jest.requireActual('../shared/stores/data-value-store.js'),
+    useValueStore: jest.fn().mockImplementation((func) => {
+        const state = {
+            isComplete: mockIsComplete,
+        }
+        return func(state)
+    }),
+}))
+
+jest.mock('../shared/use-data-value-set/use-data-value-set.js', () => ({
+    useDataValueSet: jest.fn(),
+}))
+
+const MOCK_METADATA = {
+    dataSets: {
+        data_set_id_1: {
+            id: 'data_set_id_1',
+        },
+        data_set_id_compulsory_validation_without_cdeo: {
+            id: 'data_set_id_compulsory_validation_without_cdeo',
+            compulsoryDataElementOperands: [],
+            compulsoryFieldsCompleteOnly: true,
+        },
+        data_set_id_compulsory_validation_with_cdeo: {
+            id: 'data_set_id_compulsory_validation_without_cdeo',
+            compulsoryDataElementOperands: [
+                {
+                    dataElement: {
+                        id: 'de-id-1',
+                    },
+                    categoryOptionCombo: {
+                        id: 'coc-id-1',
+                    },
+                },
+                {
+                    dataElement: {
+                        id: 'de-id-2',
+                    },
+                    categoryOptionCombo: {
+                        id: 'coc-id-2',
+                    },
+                },
+            ],
+            compulsoryFieldsCompleteOnly: true,
+        },
+    },
+}
+
+const MOCK_DATA = {
+    dataValues: {
+        'de-id-1': {
+            'coc-id-1': {
+                value: '5',
+            },
+        },
+        'de-id-2': {
+            'coc-id-2': {
+                value: '10',
+            },
+        },
+    },
+}
+
+const MOCK_DATA_INCOMPLETE = {
+    dataValues: {
+        'de-id-1': {
+            'coc-id-1': {
+                value: '5',
+            },
+        },
+    },
+}
+
+describe('CompleteButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        useImperativeValidate.mockReturnValue(mockValidate)
+    })
+
+    it('validates form and completes when clicked', () => {
+        mockIsComplete.mockReturnValue(false)
+        useDataSetId.mockReturnValue(['data_set_id_1'])
+        useDataValueSet.mockReturnValue({ data: MOCK_DATA })
+        useMetadata.mockReturnValue({ data: MOCK_METADATA })
+        const { getByText } = render(<CompleteButton />)
+
+        userEvent.click(getByText('Mark complete'))
+        expect(mockValidate).toHaveBeenCalledOnce()
+        expect(mockSetFormCompletion).toHaveBeenCalledWith({ completed: true })
+    })
+
+    it('completes if the compulsoryFieldsCompleteOnly:true but there are no compulsory data element operands', () => {
+        mockIsComplete.mockReturnValue(false)
+        useDataSetId.mockReturnValue([
+            'data_set_id_compulsory_validation_without_cdeo',
+        ])
+        useDataValueSet.mockReturnValue({ data: MOCK_DATA })
+        useMetadata.mockReturnValue({ data: MOCK_METADATA })
+        const { getByText } = render(<CompleteButton />)
+
+        userEvent.click(getByText('Mark complete'))
+        expect(mockValidate).toHaveBeenCalledOnce()
+        expect(mockSetFormCompletion).toHaveBeenCalledWith({ completed: true })
+        // completeAttempted only set if the complete is rejected due to compulsory data element operands
+        expect(mockSetCompleteAttempted).not.toHaveBeenCalled()
+    })
+
+    it('does not complete and shows error if the compulsoryFieldsCompleteOnly:true and there are compulsory data element operands without values', async () => {
+        mockIsComplete.mockReturnValue(false)
+        useDataSetId.mockReturnValue([
+            'data_set_id_compulsory_validation_with_cdeo',
+        ])
+        useDataValueSet.mockReturnValue({ data: MOCK_DATA_INCOMPLETE })
+        useMetadata.mockReturnValue({ data: MOCK_METADATA })
+        const { getByText } = render(<CompleteButton />)
+
+        userEvent.click(getByText('Mark complete'))
+        expect(mockValidate).not.toHaveBeenCalled()
+        expect(mockSetFormCompletion).not.toHaveBeenCalled()
+        expect(mockSetCompleteAttempted).toHaveBeenCalledWith(true)
+        await waitFor(() =>
+            expect(mockShow).toHaveBeenCalledWith(
+                'Compulsory fields must be filled out before completing the form'
+            )
+        )
+    })
+
+    it('completes if the compulsoryFieldsCompleteOnly:true and there are compulsory data element operands but all have values', () => {
+        mockIsComplete.mockReturnValue(false)
+        useDataSetId.mockReturnValue([
+            'data_set_id_compulsory_validation_with_cdeo',
+        ])
+        useDataValueSet.mockReturnValue({ data: MOCK_DATA })
+        useMetadata.mockReturnValue({ data: MOCK_METADATA })
+        const { getByText } = render(<CompleteButton />)
+
+        userEvent.click(getByText('Mark complete'))
+        expect(mockValidate).toHaveBeenCalledOnce()
+        expect(mockSetFormCompletion).toHaveBeenCalledWith({ completed: true })
+        // completeAttempted only set if the complete is rejected due to compulsory data element operands
+        expect(mockSetCompleteAttempted).not.toHaveBeenCalled()
+    })
+
+    it('marks form as incomplete if form is completed', () => {
+        mockIsComplete.mockReturnValue(true)
+        useDataSetId.mockReturnValue(['data_set_id_1'])
+        useDataValueSet.mockReturnValue({ data: MOCK_DATA })
+        useMetadata.mockReturnValue({ data: MOCK_METADATA })
+        const { getByText } = render(<CompleteButton />)
+
+        userEvent.click(getByText('Mark incomplete'))
+        expect(mockValidate).not.toHaveBeenCalledOnce()
+        expect(mockSetFormCompletion).toHaveBeenCalledWith({ completed: false })
+    })
+})

--- a/src/bottom-bar/use-on-complete-callback.js
+++ b/src/bottom-bar/use-on-complete-callback.js
@@ -12,6 +12,7 @@ import {
     useSetFormCompletionMutation,
     useSetFormCompletionMutationKey,
     validationResultsSidebarId,
+    useHasCompulsoryDataElementOperandsToFillOut,
 } from '../shared/index.js'
 
 const validationFailedMessage = i18n.t(
@@ -135,10 +136,20 @@ export default function useOnCompleteCallback() {
         useOnCompleteWhenValidNotRequiredClick()
     const onCompleteWithoutValidationClick =
         useOnCompleteWithoutValidationClick()
+    const hasCompulsoryDataElementOperandsToFillOut =
+        useHasCompulsoryDataElementOperandsToFillOut()
 
     return () => {
         let promise
-
+        // showErrorAlert('Complete compulsory data element operands')
+        // return Promise.resolve()
+        if (hasCompulsoryDataElementOperandsToFillOut) {
+            cancelCompletionMutation()
+            showErrorAlert(
+                'Compulsory fields must be filled out before completing form'
+            )
+            return Promise.resolve()
+        }
         if (isLoading && offline) {
             cancelCompletionMutation()
             // No need to complete when the completion request

--- a/src/bottom-bar/use-on-complete-callback.js
+++ b/src/bottom-bar/use-on-complete-callback.js
@@ -150,7 +150,7 @@ export default function useOnCompleteCallback() {
 
         if (hasCompulsoryDataElementOperandsToFillOut) {
             setCompleteAttempted(true)
-            cancelCompletionMutation()
+            cancelCompletionMutation({ completedBoolean: false })
             promise = Promise.reject(
                 new Error(
                     i18n.t(

--- a/src/context-selection/contextual-help-sidebar/cell.js
+++ b/src/context-selection/contextual-help-sidebar/cell.js
@@ -25,6 +25,9 @@ const Cell = ({ value, state }) => (
                 {state === 'SYNCED' && (
                     <div className={styles.topRightTriangle} />
                 )}
+                {state === 'COMPULSORY' && (
+                    <div className={styles.topRightAsterisk}>*</div>
+                )}
             </div>
             <div className={styles.bottomRightIndicator}>
                 {state === 'HAS_COMMENT' && (

--- a/src/context-selection/contextual-help-sidebar/cell.module.css
+++ b/src/context-selection/contextual-help-sidebar/cell.module.css
@@ -10,6 +10,7 @@
 .input {
     composes: densePadding from '../../data-workspace/inputs/inputs.module.css';
     composes: alignToEnd from '../../data-workspace/inputs/inputs.module.css';
+    padding-inline-end: 16px;
     outline: 1px solid var(--colors-grey400);
 }
 
@@ -44,4 +45,8 @@
 
 .bottomRightTriangle {
     composes: bottomRightTriangle from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
+}
+
+.topRightAsterisk {
+    composes: topRightAsterisk from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
 }

--- a/src/context-selection/contextual-help-sidebar/cells-legend.js
+++ b/src/context-selection/contextual-help-sidebar/cells-legend.js
@@ -67,6 +67,12 @@ export default function CellsLegend() {
                 name={i18n.t('Locked, not editable')}
                 state="LOCKED"
             />
+            <Divider />
+
+            <CellsLegendSymbol
+                name={i18n.t('Compulsory field')}
+                state="COMPULSORY"
+            />
         </ExpandableUnit>
     )
 }

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.test.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.test.js
@@ -2,9 +2,20 @@ import { Table } from '@dhis2/ui'
 import { getAllByTestId, getByTestId, getByText } from '@testing-library/react'
 import React from 'react'
 import { useMetadata } from '../../shared/metadata/use-metadata.js'
+import { useDataSetId } from '../../shared/use-context-selection/use-context-selection.js'
 import { render } from '../../test-utils/index.js'
 import { FinalFormWrapper } from '../final-form-wrapper.js'
 import { CategoryComboTableBody } from './category-combo-table-body.js'
+
+jest.mock(
+    '../../shared/use-context-selection/use-context-selection.js',
+    () => ({
+        ...jest.requireActual(
+            '../../shared/use-context-selection/use-context-selection.js'
+        ),
+        useDataSetId: jest.fn(),
+    })
+)
 
 jest.mock('../../shared/metadata/use-metadata.js', () => ({
     useMetadata: jest.fn(),
@@ -453,6 +464,7 @@ const metadata = {
 
 describe('<CategoryComboTableBody />', () => {
     useMetadata.mockReturnValue({ data: metadata })
+    useDataSetId.mockReturnValue(['dataSet1'])
 
     it('should render rows and columns based on the data elements and categorycombo', () => {
         const tableDataElements = [

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -108,6 +108,11 @@
     border-inline-start: 3px solid transparent;
 }
 
+.topRightAsterisk {
+    color: var(--colors-grey600);
+    inline-size: 8px;
+}
+
 .locked {
     background-color: var(--colors-grey050);
 }

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -73,6 +73,9 @@ export function InnerWrapper({
         dataElementId: deId,
         categoryOptionComboId: cocId,
     })
+    const completeAttempted = useEntryFormStore((state) =>
+        state.getCompleteAttempted()
+    )
 
     const {
         input: { value },
@@ -104,6 +107,7 @@ export function InnerWrapper({
         (state) => state.clearErrorByDataValueParams
     )
     const warning = useEntryFormStore((state) => state.getWarning(fieldname))
+
     const fieldErrorMessage = error ?? warning
 
     const errorMessage =
@@ -117,16 +121,18 @@ export function InnerWrapper({
         )
 
     const valueSynced = data.lastSyncedValue === value
-    const showSynced = dirty && valueSynced
+    const showSynced = dirty && valueSynced && (!isRequired || !!value)
     // todo: maybe use mutation state to improve this style handling
     // see https://dhis2.atlassian.net/browse/TECH-1316
-    const cellStateClassName = invalid
-        ? styles.invalid
-        : warning
-        ? styles.warning
-        : activeMutations === 0 && showSynced
-        ? styles.synced
-        : null
+
+    const cellStateClassName =
+        invalid || (isRequired && !value && completeAttempted)
+            ? styles.invalid
+            : warning
+            ? styles.warning
+            : activeMutations === 0 && showSynced
+            ? styles.synced
+            : null
 
     // initalize lastSyncedValue
     useEffect(

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -10,12 +10,13 @@ import {
     useValueStore,
     useSyncErrorsStore,
     useEntryFormStore,
+    useIsCompulsoryDataElementOperand,
 } from '../../shared/index.js'
 import styles from './data-entry-cell.module.css'
 import { ValidationTooltip } from './validation-tooltip.js'
 
 /** Three dots or triangle in top-right corner of cell */
-const SyncStatusIndicator = ({ error, isLoading, isSynced }) => {
+const SyncStatusIndicator = ({ error, isLoading, isSynced, isRequired }) => {
     let statusIcon = null
     if (isLoading) {
         statusIcon = <IconMore16 color={colors.grey700} />
@@ -23,6 +24,8 @@ const SyncStatusIndicator = ({ error, isLoading, isSynced }) => {
         statusIcon = <IconWarningFilled16 color={colors.yellow800} />
     } else if (isSynced) {
         statusIcon = <div className={styles.topRightTriangle} />
+    } else if (isRequired) {
+        statusIcon = <div className={styles.topRightAsterisk}>*</div>
     }
     return (
         <div className={cx(styles.topRightIndicator, styles.hideForPrint)}>
@@ -33,6 +36,7 @@ const SyncStatusIndicator = ({ error, isLoading, isSynced }) => {
 SyncStatusIndicator.propTypes = {
     error: PropTypes.object,
     isLoading: PropTypes.bool,
+    isRequired: PropTypes.bool,
     isSynced: PropTypes.bool,
 }
 
@@ -65,6 +69,10 @@ export function InnerWrapper({
             categoryOptionComboId: cocId,
         })
     )
+    const isRequired = useIsCompulsoryDataElementOperand({
+        dataElementId: deId,
+        categoryOptionComboId: cocId,
+    })
 
     const {
         input: { value },
@@ -156,6 +164,7 @@ export function InnerWrapper({
             >
                 {children}
                 <SyncStatusIndicator
+                    isRequired={isRequired}
                     isLoading={activeMutations > 0}
                     isSynced={showSynced}
                     error={syncError}

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -15,6 +15,7 @@ import {
     useIsValidSelection,
     useValueStore,
     dataValueSetQueryKey,
+    useEntryFormStore,
 } from '../shared/index.js'
 import styles from './data-workspace.module.css'
 import { EntryForm } from './entry-form.js'
@@ -33,6 +34,10 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
     useEffect(() => {
         updateStore(initialDataValuesFetch.data)
     }, [updateStore, initialDataValuesFetch.data])
+
+    const setCompleteAttempted = useEntryFormStore(
+        (state) => state.setCompleteAttempted
+    )
 
     const isValidSelection = useIsValidSelection()
     const [dataSetId] = useDataSetId()
@@ -55,8 +60,11 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
                     cancelRefetch: false,
                 }
             )
+
+            // reset the completionAttempted store for new form
+            setCompleteAttempted(false)
         }
-    }, [validFormKey, queryClient])
+    }, [validFormKey, queryClient, setCompleteAttempted])
 
     if (selectionHasNoFormMessage) {
         const title = i18n.t('The current selection does not have a form')

--- a/src/shared/completion/use-imperative-cancel-completion-mutation.js
+++ b/src/shared/completion/use-imperative-cancel-completion-mutation.js
@@ -8,7 +8,7 @@ export default function useImperativeCancelCompletionMutation() {
     const mutationKey = useSetFormCompletionMutationKey()
     const dataValueSetQueryKey = useDataValueSetQueryKey()
 
-    return () => {
+    return ({ completedBoolean } = {}) => {
         const foundMutation = mutationCache.find({ mutationKey })
 
         if (!foundMutation) {
@@ -30,7 +30,7 @@ export default function useImperativeCancelCompletionMutation() {
                 ...previousDataValueSet,
                 completeStatus: {
                     ...previousDataValueSet.completeStatus,
-                    complete: !completed,
+                    complete: completedBoolean ?? !completed,
                 },
             })
         )

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -23,3 +23,7 @@ export * from './default-on-success.js'
 export * from './use-will-component-unmount.js'
 export * from './api-errors/index.js'
 export * from './use-org-unit/use-organisation-unit.js'
+export {
+    useIsCompulsoryDataElementOperand,
+    useHasCompulsoryDataElementOperandsToFillOut,
+} from './use-is-compulsory-data-element-operand.js'

--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -124,7 +124,7 @@ export const getCategoryOptionsByCategoryOptionComboId = createCachedSelector(
 export const getCompulsoryDataElementOperandsSet = createCachedSelector(
     getDataSetById,
     (dataSet) => {
-        if (!dataSet) {
+        if (!dataSet || !dataSet.compulsoryDataElementOperands) {
             return new Set()
         }
         return new Set(

--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -29,6 +29,8 @@ export const getIndicators = (metadata) => metadata.indicators
 export const getDataSets = (metadata) => metadata.dataSets
 export const getSections = (metadata) => metadata.sections
 export const getOptionSets = (metadata) => metadata.optionSets
+export const getCompulsoryDataElementOperands = (metadata) =>
+    metadata.compulsoryDataElementOperands
 // Select by id
 
 export const getCategoryById = (metadata, id) => getCategories(metadata)[id]
@@ -115,6 +117,24 @@ export const getCategoryOptionsByCategoryOptionComboId = createCachedSelector(
         return []
     }
 )((_, categoryOptionComboId) => categoryOptionComboId)
+
+/**
+ * @param {*} metadata
+ */
+export const getCompulsoryDataElementOperandsSet = createCachedSelector(
+    getDataSetById,
+    (dataSet) => {
+        if (!dataSet) {
+            return new Set()
+        }
+        return new Set(
+            dataSet.compulsoryDataElementOperands?.map(
+                (operand) =>
+                    `${operand?.dataElement?.id}.${operand?.categoryOptionCombo?.id}`
+            )
+        )
+    }
+)((_, dataSetId) => dataSetId)
 
 /**
  * @param {*} metadata

--- a/src/shared/stores/entry-form-store.js
+++ b/src/shared/stores/entry-form-store.js
@@ -4,6 +4,7 @@ import create from 'zustand'
 const inititalState = {
     errors: {},
     warnings: {},
+    completeAttempted: false,
 }
 
 export const useEntryFormStore = create((set, get) => ({
@@ -19,6 +20,8 @@ export const useEntryFormStore = create((set, get) => ({
         const newWarnings = setIn(warnings, fieldname, warning) ?? {}
         set({ warnings: newWarnings })
     },
+    getCompleteAttempted: () => get().completeAttempted,
+    setCompleteAttempted: (bool) => set({ completeAttempted: bool }),
     // could add getNumberOfWarnings if needed
 }))
 

--- a/src/shared/use-is-compulsory-data-element-operand.js
+++ b/src/shared/use-is-compulsory-data-element-operand.js
@@ -9,6 +9,9 @@ export const useIsCompulsoryDataElementOperand = ({
 }) => {
     const { data: metadata } = useMetadata()
     const [dataSetId] = useDataSetId()
+    if (!dataSetId) {
+        return false
+    }
     const compulsoryDataElementOperandsSet =
         selectors.getCompulsoryDataElementOperandsSet(metadata, dataSetId)
     return compulsoryDataElementOperandsSet.has(
@@ -22,7 +25,10 @@ export const useHasCompulsoryDataElementOperandsToFillOut = () => {
     const { data: metadata } = useMetadata()
     const [dataSetId] = useDataSetId()
     const hasCompulsoryDataElementOperandsToFillOut = useMemo(() => {
-        const dataSet = selectors.getDataSetById(dataSetId)
+        if (!dataSetId) {
+            return false
+        }
+        const dataSet = selectors.getDataSetById(metadata, dataSetId)
 
         const { compulsoryFieldsCompleteOnly } = dataSet || {}
 

--- a/src/shared/use-is-compulsory-data-element-operand.js
+++ b/src/shared/use-is-compulsory-data-element-operand.js
@@ -1,0 +1,51 @@
+import { useMemo } from 'react'
+import { useMetadata, selectors } from './metadata/index.js'
+import { useDataSetId } from './use-context-selection/use-context-selection.js'
+import { useDataValueSet } from './use-data-value-set/use-data-value-set.js'
+
+export const useIsCompulsoryDataElementOperand = ({
+    dataElementId,
+    categoryOptionComboId,
+}) => {
+    const { data: metadata } = useMetadata()
+    const [dataSetId] = useDataSetId()
+    const compulsoryDataElementOperandsSet =
+        selectors.getCompulsoryDataElementOperandsSet(metadata, dataSetId)
+    return compulsoryDataElementOperandsSet.has(
+        `${dataElementId}.${categoryOptionComboId}`
+    )
+}
+
+export const useHasCompulsoryDataElementOperandsToFillOut = () => {
+    const { data } = useDataValueSet()
+
+    const { data: metadata } = useMetadata()
+    const [dataSetId] = useDataSetId()
+    const hasCompulsoryDataElementOperandsToFillOut = useMemo(() => {
+        const dataSet = selectors.getDataSetById(dataSetId)
+
+        const { compulsoryFieldsCompleteOnly } = dataSet || {}
+
+        if (!compulsoryFieldsCompleteOnly) {
+            return false
+        }
+
+        const compulsoryDataElementOperandsSet =
+            selectors.getCompulsoryDataElementOperandsSet(metadata, dataSetId)
+
+        let hasEmptyCompulsoryDataElementOperands = false
+        for (const operand of compulsoryDataElementOperandsSet) {
+            const [dataElementId, categoryOptionComboId] = operand.split('.')
+            if (
+                !data?.dataValues?.[dataElementId]?.[categoryOptionComboId]
+                    ?.value
+            ) {
+                hasEmptyCompulsoryDataElementOperands = true
+                break
+            }
+        }
+        return hasEmptyCompulsoryDataElementOperands
+    }, [data?.dataValues, dataSetId, metadata])
+
+    return hasCompulsoryDataElementOperandsToFillOut
+}

--- a/src/shared/validation/index.js
+++ b/src/shared/validation/index.js
@@ -1,5 +1,5 @@
 export { default as buildValidationResult } from './build-validation-result.js'
 export { isInteger } from './is-integer.js'
 export * from './query-key-factory.js'
-export { default as useImperativeValidate } from './use-imperative-validate.js'
+export { useImperativeValidate } from './use-imperative-validate.js'
 export { default as useValidationResult } from './use-validation-result.js'

--- a/src/shared/validation/use-imperative-validate.js
+++ b/src/shared/validation/use-imperative-validate.js
@@ -12,7 +12,7 @@ import {
  * @params {Object} options
  * @params {Boolean} options.enabled - Defaults to `true`
  **/
-export default function useImperativeValidate() {
+export const useImperativeValidate = () => {
     const client = useQueryClient()
     const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
     const {

--- a/src/shared/validation/use-imperative-validate.test.js
+++ b/src/shared/validation/use-imperative-validate.test.js
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { Wrapper } from '../../test-utils/index.js'
-import useImperativeValidate from './use-imperative-validate.js'
+import { useImperativeValidate } from './use-imperative-validate.js'
 
 jest.mock('@tanstack/react-query', () => {
     const originalModule = jest.requireActual('@tanstack/react-query')


### PR DESCRIPTION
This PR addresses the referenced ticket ([DHIS2-17647](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17647)) and in general

(Note when I was testing this, I just made a couple of new data elements and assigned them to a new data set and then marked some as compulsory data element operands)

**Before:**
- no handling of compulsory data element operands

**After:**

- compulsory data element operands are marked with an `*` when they are empty. They then will get other applicable styling as values are entered (e.g. synced, error, warning)
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/f61069e3-fe4a-4cd2-aa72-6fd526e7707d">

- if the data set has `compulsoryFieldsCompleteOnly: true` ("Complete allowed only if compulsory fields are filled in" in the maintenance app), a snack bar message will appear saying that the form cannot be completed due to compulsory data element operands and the styling on the cells will be set to red/invalid/not saved (this styling will update as values are entered)
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/3e16ed20-bd12-4a1c-b1a4-47b5540a3b2a">


### Testing
- I've added automated tests on the complete-button to test that the checks preventing the completion based on the values/compulsoryDataElementOperands is working (i.e. this an integration level test which tests `useHasCompulsoryDataElementOperandsToFillOut` hook and logic preventing completion in `useOnCompleteCallback`)
- I have not added any automated tests for the styling (and hence implicit test of `useIsCompulsoryDataElementOperand` hook) partly because we didn't have existing tests and more because the InnerWrapper component where this can be tested is being refactored due to the performance PR (https://github.com/dhis2/aggregate-data-entry-app/pull/425) so the mocking would have to be redone if I added some now. I find these tests less crucial in any case because the styling doesn't block user from entering data.

I've also done some manual testing (see note above). 

[DHIS2-17647]: https://dhis2.atlassian.net/browse/DHIS2-17647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ