### PR TITLE
fix: test ancestor orgunits for aoc assignment [DHIS2-18526]

### DIFF
--- a/src/context-selection/attribute-option-combo-selector-bar-item/attribute-option-combo-selector-bar-item.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/attribute-option-combo-selector-bar-item.js
@@ -10,6 +10,7 @@ import {
     useOrgUnitId,
     usePeriodId,
     useAttributeOptionComboSelection,
+    useOrgUnit,
 } from '../../shared/index.js'
 import CategoriesMenu from './categories-menu.js'
 import useSelected from './use-selected.js'
@@ -58,6 +59,8 @@ export default function AttributeOptionComboSelectorBarItem({
         useAttributeOptionComboSelection()
     const { systemInfo = {} } = useConfig()
     const { calendar = 'gregory' } = systemInfo
+    const { data: orgUnitData } = useOrgUnit()
+    const orgUnitPath = orgUnitData?.path
 
     const relevantCategoriesWithOptions =
         selectors.getCategoriesWithOptionsWithinPeriodWithOrgUnit(
@@ -65,6 +68,7 @@ export default function AttributeOptionComboSelectorBarItem({
             dataSetId,
             periodId,
             orgUnitId,
+            orgUnitPath,
             calendar
         )
 

--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -508,10 +508,21 @@ const isOptionWithinPeriod = ({
     return true
 }
 
-const isOptionAssignedToOrgUnit = ({ categoryOption, orgUnitId }) => {
+const isOptionAssignedToOrgUnit = ({
+    categoryOption,
+    orgUnitId,
+    orgUnitPath,
+}) => {
     // by default,
     if (!categoryOption?.organisationUnits?.length) {
         return true
+    }
+    // if offline, the orgUnitPath may be undefined (we do not have path details in metadata)
+    if (orgUnitPath) {
+        const ancestors = orgUnitPath.split('/').filter((o) => o.length)
+        return ancestors.some((ancestor) =>
+            categoryOption?.organisationUnits.includes(ancestor)
+        )
     }
     return categoryOption?.organisationUnits.includes(orgUnitId)
 }
@@ -532,8 +543,16 @@ export const getCategoriesWithOptionsWithinPeriodWithOrgUnit =
         getDataSetById,
         (_, __, periodId) => periodId,
         (_, __, ___, orgUnitId) => orgUnitId,
-        (_, __, ___, ____, calendar) => calendar,
-        (metadata, dataSet, periodId, orgUnitId, calendar = 'gregory') => {
+        (_, __, ___, ____, orgUnitPath) => orgUnitPath,
+        (_, __, ___, ____, _____, calendar) => calendar,
+        (
+            metadata,
+            dataSet,
+            periodId,
+            orgUnitId,
+            orgUnitPath,
+            calendar = 'gregory'
+        ) => {
             if (!dataSet?.id || !periodId) {
                 return []
             }
@@ -602,6 +621,7 @@ export const getCategoriesWithOptionsWithinPeriodWithOrgUnit =
                         isOptionAssignedToOrgUnit({
                             categoryOption,
                             orgUnitId,
+                            orgUnitPath,
                         })
                 ),
             }))

--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -1373,6 +1373,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
             const orgunitid = 'orgunit-id-z'
+            const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -1431,6 +1432,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 datasetid,
                 periodid,
                 orgunitid,
+                orgunitpath,
                 calendar
             )
 
@@ -1441,6 +1443,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
             const orgunitid = 'orgunit-id-z'
+            const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -1495,6 +1498,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 datasetid,
                 periodid,
                 orgunitid,
+                orgunitpath,
                 calendar
             )
 
@@ -1505,6 +1509,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
             const orgunitid = 'orgunit-id-z'
+            const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -1566,6 +1571,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 datasetid,
                 periodid,
                 orgunitid,
+                orgunitpath,
                 calendar
             )
 
@@ -1576,6 +1582,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
             const orgunitid = 'orgunit-id-z'
+            const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -1637,6 +1644,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 datasetid,
                 periodid,
                 orgunitid,
+                orgunitpath,
                 calendar
             )
 
@@ -1647,6 +1655,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
             const orgunitid = 'orgunit-id-z'
+            const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -1716,6 +1725,186 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 datasetid,
                 periodid,
                 orgunitid,
+                orgunitpath,
+                calendar
+            )
+
+            expect(actual).toEqual(expected)
+        })
+
+        it('should restrict based on orgunitid alone if orgunitpath is undefined ', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
+            const orgunitpath = undefined
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2', 'cat-id-3'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': {
+                        id: 'cat-id-a',
+                        organisationUnits: ['fake-orgunit1', 'orgunit-id-y'],
+                    },
+                    'cat-id-b': {
+                        id: 'cat-id-b',
+                        organisationUnits: ['fake-orgunit1'],
+                    },
+                    'cat-id-c': {
+                        id: 'cat-id-c',
+                        organisationUnits: ['fake-orgunit2'],
+                    },
+                    'cat-id-1': {
+                        id: 'cat-id-1',
+                        organisationUnits: ['orgunit-id-z'],
+                    },
+                    'cat-id-2': { id: 'cat-id-2', organisationUnits: [] },
+                    'cat-id-3': {
+                        id: 'cat-id-3',
+                        organisationUnits: ['orgunit-id-x'],
+                    },
+                },
+            }
+
+            const calendar = 'gregory'
+
+            const expected = [
+                {
+                    categoryOptions: [],
+                    id: 'co-id-letter',
+                },
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-1', organisationUnits: ['orgunit-id-z'] },
+                        { id: 'cat-id-2', organisationUnits: [] },
+                    ],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
+                metadata,
+                datasetid,
+                periodid,
+                orgunitid,
+                orgunitpath,
+                calendar
+            )
+
+            expect(actual).toEqual(expected)
+        })
+
+        it('should check if category option is assigned to ancestor org unit when filtering based on org units', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
+            const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2', 'cat-id-3'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': {
+                        id: 'cat-id-a',
+                        organisationUnits: ['fake-orgunit1', 'orgunit-id-y'],
+                    },
+                    'cat-id-b': {
+                        id: 'cat-id-b',
+                        organisationUnits: ['fake-orgunit1'],
+                    },
+                    'cat-id-c': {
+                        id: 'cat-id-c',
+                        organisationUnits: ['fake-orgunit2'],
+                    },
+                    'cat-id-1': {
+                        id: 'cat-id-1',
+                        organisationUnits: ['orgunit-id-z'],
+                    },
+                    'cat-id-2': { id: 'cat-id-2', organisationUnits: [] },
+                    'cat-id-3': {
+                        id: 'cat-id-3',
+                        organisationUnits: ['orgunit-id-x'],
+                    },
+                },
+            }
+
+            const calendar = 'gregory'
+
+            const expected = [
+                {
+                    categoryOptions: [
+                        {
+                            id: 'cat-id-a',
+                            organisationUnits: [
+                                'fake-orgunit1',
+                                'orgunit-id-y',
+                            ],
+                        },
+                    ],
+                    id: 'co-id-letter',
+                },
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-1', organisationUnits: ['orgunit-id-z'] },
+                        { id: 'cat-id-2', organisationUnits: [] },
+                        { id: 'cat-id-3', organisationUnits: ['orgunit-id-x'] },
+                    ],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
+                metadata,
+                datasetid,
+                periodid,
+                orgunitid,
+                orgunitpath,
                 calendar
             )
 

--- a/src/shared/use-context-selection/use-manage-inter-param-dependencies.js
+++ b/src/shared/use-context-selection/use-manage-inter-param-dependencies.js
@@ -4,6 +4,7 @@ import { createFixedPeriodFromPeriodId } from '@dhis2/multi-calendar-dates'
 import { useEffect, useState } from 'react'
 import { useMetadata, selectors } from '../metadata/index.js'
 import { periodTypesMapping } from '../period/index.js'
+import { useOrgUnit } from '../use-org-unit/use-organisation-unit.js'
 import { filterObject } from '../utils.js'
 import {
     usePeriodId,
@@ -125,6 +126,8 @@ function useHandleOrgUnitIdChange() {
     const [periodId] = usePeriodId()
     const [orgUnitId] = useOrgUnitId()
     const [prevOrgUnitId, setPrevOrgUnitId] = useState(orgUnitId)
+    const { data: orgUnitData } = useOrgUnit()
+    const orgUnitPath = orgUnitData?.path
     const [attributeOptionComboSelection, setAttributeOptionComboSelection] =
         useAttributeOptionComboSelection()
     const { systemInfo = {} } = useConfig()
@@ -136,6 +139,7 @@ function useHandleOrgUnitIdChange() {
             dataSetId,
             periodId,
             orgUnitId,
+            orgUnitPath,
             calendar
         )
 
@@ -208,6 +212,8 @@ function useHandlePeriodIdChange() {
         useAttributeOptionComboSelection()
     const [dataSetId] = useDataSetId()
     const [orgUnitId] = useOrgUnitId()
+    const { data: orgUnitData } = useOrgUnit()
+    const orgUnitPath = orgUnitData?.path
     const [periodId] = usePeriodId()
     const [prevPeriodId, setPrevPeriodId] = useState(periodId)
     const { systemInfo = {} } = useConfig()
@@ -218,6 +224,7 @@ function useHandlePeriodIdChange() {
             dataSetId,
             periodId,
             orgUnitId,
+            orgUnitPath,
             calendar
         )
 


### PR DESCRIPTION
### Background

See the ticket https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18526
(Note the ticket has some metadata that can be imported for testing purposes)

### Notes
We need to get orgUnit.path to be able to check if an attribute option is assigned to an ancestor of the selected organisation unit and to determine if that attribute option should be selectable. 

We can get this with the existing hook/query `useOrgUnit`, though it is not available offline. We've decided (see ticket) that we will not modify the UI in case we are offline. When offline, we will thus check against the selected org unit only (not its ancestors), so the available options could be incomplete, but we will consider this enough of an edge case not to modify the UI for this.

### Testing
I've manually tested with the metadata that was attached to the ticket
For automated tests, I've added some tests for the selector that handles the logic for determining the relevant attribute options. 
Our selectors are more generally tested in cypress against Sierra Leone database, but I don't want to add a cypress test as we'd need to do some SL database edits and then we have additional cypress tests that I feel like mostly become a bit of a maintenance challenge over time. I think this ticket covers a somewhat limited use case, so I'm okay with just the additional automated tests at the unit level (selector.js) and don't think the time investment to make new integration level tests in jest is justified.