### PR TITLE
fix: when sanitizing text and target to links so they work w global s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@tanstack/react-query-persist-client": "4.24.10",
         "chart.js": "3.9.1",
         "classnames": "2.3.2",
-        "dompurify": "^3.0.9",
+        "dompurify": "^3.2.4",
         "expr-eval": "2.0.2",
         "final-form": "4.20.9",
         "final-form-set-field-data": "1.0.2",

--- a/src/data-workspace/section-form/sanitized-text.js
+++ b/src/data-workspace/section-form/sanitized-text.js
@@ -1,11 +1,11 @@
-import * as DOMPurify from 'dompurify'
+import DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 DOMPurify.addHook('afterSanitizeAttributes', function (node) {
     if (node.tagName.toLowerCase() === 'a') {
         node.setAttribute('target', '_blank')
-        node.setAttribute('rel', 'noopener')
+        node.setAttribute('rel', 'noreferrer')
     }
 })
 

--- a/src/data-workspace/section-form/sanitized-text.js
+++ b/src/data-workspace/section-form/sanitized-text.js
@@ -2,6 +2,13 @@ import * as DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+    if (node.tagName.toLowerCase() === 'a') {
+        node.setAttribute('target', '_blank')
+        node.setAttribute('rel', 'noopener')
+    }
+})
+
 export const SanitizedText = ({ children, className }) => {
     if (!children) {
         return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -4147,7 +4147,7 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/trusted-types@^2.0.2":
+"@types/trusted-types@^2.0.2", "@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
@@ -6943,10 +6943,12 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.9.tgz#b3f362f24b99f53498c75d43ecbd784b0b3ad65e"
-  integrity sha512-uyb4NDIvQ3hRn6NiC+SIFaP4mJ/MdXlvtunaqK9Bn6dD3RuB/1S/gasEjDHD8eiaqdSael2vBv+hOs7Y+jhYOQ==
+dompurify@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
+  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
After the bug bash, we discovered an issue with the text users can add in the Maintenance app for dataset's sections, and datasets (titles, subtitles, pretext, etc.), and the global shell.
As a quick reminder,  currently, users can add some text to datasets, and within this text, they are allowed to include basic HTML elements (a, b, strong, u, em). These elements are then rendered accordingly in the Data Entry app.
The issue we’ve found is that if a user include a link to external URLs and has the the global shell enabled, these are not working.
After a discussion, we decided that the easiest solution would be to change the behaviour so that if a user adds a link in the text, we will programmatically modify it to open in a new tab by adding target="_blank" and rel="noopener" before rendering.