### PR TITLE
fix: custom form styling [BETA-362]

### DIFF
--- a/src/data-workspace/custom-form/custom-form.module.css
+++ b/src/data-workspace/custom-form/custom-form.module.css
@@ -1,3 +1,7 @@
+.customForm {
+    width: 100%;
+}
+
 .customForm table {
     border-collapse: collapse;
     block-size: 100%;

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -22,6 +22,7 @@
     padding: 8px;
     background-color: #fff;
     inline-size: max-content;
+    width: 100%;
 }
 
 .footer {


### PR DESCRIPTION
This is a fix for https://dhis2.atlassian.net/browse/BETA-362 (replicated by https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-19400)

I have, to be honest, not looked in much detail about why the auto width is not appropriately getting the size of this form, but it seems like it should be fine to explicitly set width: 100% on these containers in any case.

**Before:**
![image](https://github.com/user-attachments/assets/9ad445e1-b0fa-40bc-9fd9-c81032b807c1)


**After:**
![image](https://github.com/user-attachments/assets/61379360-35f7-4351-9d12-5fad69e6c87d)
