### PR TITLE
fix: prevent crash with missing category options [DHIS2-19523]

### DIFF
--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -530,11 +530,12 @@ const isOptionAssignedToOrgUnit = ({
 }
 
 const resolveCategoryOptionIds = (categories, categoryOptions) => {
+    // note: an option may be missing because of sharing settings, so filter out undefineds
     return categories.map((category) => ({
         ...category,
-        categoryOptions: category.categoryOptions.map(
-            (id) => categoryOptions[id]
-        ),
+        categoryOptions: category.categoryOptions
+            .map((id) => categoryOptions[id])
+            .filter((opt) => opt !== undefined),
     }))
 }
 

--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -1911,4 +1911,92 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             expect(actual).toEqual(expected)
         })
     })
+    it('filters out category options which are missing from metadata (due to sharing)', () => {
+        const datasetid = 'dataset-id-1a'
+        const periodid = '202201'
+        const orgunitid = 'orgunit-id-z'
+        const orgunitpath = '/orgunit-id-x/orgunit-id-y/orgunit-id-z'
+
+        const catcomboid = 'categorycombo-id-1'
+
+        const metadata = {
+            dataSets: {
+                [datasetid]: {
+                    categoryCombo: { id: catcomboid },
+                    periodType: 'Monthly',
+                    id: datasetid,
+                },
+            },
+            categoryCombos: {
+                [catcomboid]: {
+                    id: catcomboid,
+                    categories: ['co-id-letter', 'co-id-number'],
+                },
+            },
+            categories: {
+                'co-id-letter': {
+                    id: 'co-id-letter',
+                    categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                },
+                'co-id-number': {
+                    id: 'co-id-number',
+                    categoryOptions: ['cat-id-1', 'cat-id-2', 'cat-id-3'],
+                },
+            },
+            categoryOptions: {
+                'cat-id-a': {
+                    id: 'cat-id-a',
+                    organisationUnits: ['fake-orgunit1', 'orgunit-id-y'],
+                },
+                'cat-id-b': {
+                    id: 'cat-id-b',
+                    organisationUnits: ['fake-orgunit1'],
+                },
+                'cat-id-c': {
+                    id: 'cat-id-c',
+                    organisationUnits: ['fake-orgunit2'],
+                },
+                'cat-id-1': {
+                    id: 'cat-id-1',
+                    organisationUnits: ['orgunit-id-z'],
+                },
+                'cat-id-3': {
+                    id: 'cat-id-3',
+                    organisationUnits: ['orgunit-id-x'],
+                },
+            },
+        }
+
+        const calendar = 'gregory'
+
+        const expected = [
+            {
+                categoryOptions: [
+                    {
+                        id: 'cat-id-a',
+                        organisationUnits: ['fake-orgunit1', 'orgunit-id-y'],
+                    },
+                ],
+                id: 'co-id-letter',
+            },
+            {
+                categoryOptions: [
+                    { id: 'cat-id-1', organisationUnits: ['orgunit-id-z'] },
+                    { id: 'cat-id-3', organisationUnits: ['orgunit-id-x'] },
+                ],
+                id: 'co-id-number',
+            },
+        ]
+
+        const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
+            metadata,
+            datasetid,
+            periodid,
+            orgunitid,
+            orgunitpath,
+            calendar
+        )
+
+        expect(actual).toEqual(expected)
+    })
 })


### PR DESCRIPTION
see https://dhis2.atlassian.net/browse/DHIS2-19523

This fixes the case where a user does not have access to certain individual attribute options associated with a attribute (this can happen when user does not have sharing for the specific attribute).

**Testing**
You can test this with admin user (by following instructions on ticket) or by unsharing a partner option and then opening 'ART Monthly Summary' data set.

I've also added an automated test to confirm that undefined options get sorted out.