### PR TITLE
fix: number only totals [DHIS2-18640]

### DIFF
--- a/src/data-workspace/category-combo-table-body/category-combo-table-body-header.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body-header.js
@@ -55,6 +55,7 @@ export const CategoryComboTableBodyHeader = ({
     categoryOptionCombos,
     categories,
     checkTableActive,
+    nonNumberValueType,
 }) => {
     const { deId: activeDeId, cocId: activeCocId } = useActiveCell()
 
@@ -109,7 +110,13 @@ export const CategoryComboTableBodyHeader = ({
                     <PaddingCell key={i} />
                 ))}
                 {renderRowTotals && colInfoIndex === 0 && (
-                    <TotalHeader rowSpan={categories.length} />
+                    <>
+                        {nonNumberValueType ? (
+                            <PaddingCell key={'total_header_padding'} />
+                        ) : (
+                            <TotalHeader rowSpan={categories.length} />
+                        )}
+                    </>
                 )}
             </TableRowHead>
         )
@@ -125,6 +132,7 @@ CategoryComboTableBodyHeader.propTypes = {
         })
     ),
     checkTableActive: PropTypes.func,
+    nonNumberValueType: PropTypes.bool,
     paddingCells: PropTypes.array,
     renderRowTotals: PropTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body-header.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body-header.js
@@ -55,7 +55,7 @@ export const CategoryComboTableBodyHeader = ({
     categoryOptionCombos,
     categories,
     checkTableActive,
-    nonNumberValueType,
+    allNonNumberValueType,
 }) => {
     const { deId: activeDeId, cocId: activeCocId } = useActiveCell()
 
@@ -111,7 +111,7 @@ export const CategoryComboTableBodyHeader = ({
                 ))}
                 {renderRowTotals && colInfoIndex === 0 && (
                     <>
-                        {nonNumberValueType ? (
+                        {allNonNumberValueType ? (
                             <PaddingCell key={'total_header_padding'} />
                         ) : (
                             <TotalHeader rowSpan={categories.length} />
@@ -124,6 +124,7 @@ export const CategoryComboTableBodyHeader = ({
 }
 
 CategoryComboTableBodyHeader.propTypes = {
+    allNonNumberValueType: PropTypes.bool,
     categories: PropTypes.array,
     // Note that this must be the sorted categoryoOptionCombos, eg. in the same order as they are rendered
     categoryOptionCombos: PropTypes.arrayOf(
@@ -132,7 +133,6 @@ CategoryComboTableBodyHeader.propTypes = {
         })
     ),
     checkTableActive: PropTypes.func,
-    nonNumberValueType: PropTypes.bool,
     paddingCells: PropTypes.array,
     renderRowTotals: PropTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body-header.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body-header.js
@@ -55,7 +55,7 @@ export const CategoryComboTableBodyHeader = ({
     categoryOptionCombos,
     categories,
     checkTableActive,
-    allNonNumberValueType,
+    hideRowTotalsDueToNonNumberValueTypes,
 }) => {
     const { deId: activeDeId, cocId: activeCocId } = useActiveCell()
 
@@ -111,7 +111,7 @@ export const CategoryComboTableBodyHeader = ({
                 ))}
                 {renderRowTotals && colInfoIndex === 0 && (
                     <>
-                        {allNonNumberValueType ? (
+                        {hideRowTotalsDueToNonNumberValueTypes ? (
                             <PaddingCell key={'total_header_padding'} />
                         ) : (
                             <TotalHeader rowSpan={categories.length} />
@@ -124,7 +124,6 @@ export const CategoryComboTableBodyHeader = ({
 }
 
 CategoryComboTableBodyHeader.propTypes = {
-    allNonNumberValueType: PropTypes.bool,
     categories: PropTypes.array,
     // Note that this must be the sorted categoryoOptionCombos, eg. in the same order as they are rendered
     categoryOptionCombos: PropTypes.arrayOf(
@@ -133,6 +132,7 @@ CategoryComboTableBodyHeader.propTypes = {
         })
     ),
     checkTableActive: PropTypes.func,
+    hideRowTotalsDueToNonNumberValueTypes: PropTypes.bool,
     paddingCells: PropTypes.array,
     renderRowTotals: PropTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.js
@@ -2,7 +2,7 @@ import { TableBody, TableCell, TableRow } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
-import { selectors, useMetadata } from '../../shared/index.js'
+import { selectors, useMetadata, NUMBER_TYPES } from '../../shared/index.js'
 import { DataEntryCell, DataEntryField } from '../data-entry-cell/index.js'
 import { getFieldId } from '../get-field-id.js'
 import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.js'
@@ -58,6 +58,9 @@ export const CategoryComboTableBody = React.memo(
             }
         })
         const hiddenItemsCount = filteredDeIds.size
+        const nonNumberValueType = dataElements
+            .map(({ valueType }) => valueType)
+            .some((valueType) => !NUMBER_TYPES.includes(valueType))
 
         return (
             <TableBody
@@ -68,7 +71,7 @@ export const CategoryComboTableBody = React.memo(
                 <CategoryComboTableBodyHeader
                     categoryOptionCombos={sortedCOCs}
                     categories={categories}
-                    renderRowTotals={renderRowTotals}
+                    renderRowTotals={renderRowTotals && !nonNumberValueType}
                     paddingCells={paddingCells}
                     checkTableActive={checkTableActive}
                 />
@@ -101,7 +104,7 @@ export const CategoryComboTableBody = React.memo(
                                     className={styles.tableCell}
                                 />
                             ))}
-                            {renderRowTotals && (
+                            {renderRowTotals && !nonNumberValueType && (
                                 <RowTotal
                                     dataElements={dataElements}
                                     categoryOptionCombos={sortedCOCs}
@@ -111,7 +114,7 @@ export const CategoryComboTableBody = React.memo(
                         </TableRow>
                     )
                 })}
-                {renderColumnTotals && (
+                {renderColumnTotals && !nonNumberValueType && (
                     <ColumnTotals
                         paddingCells={paddingCells}
                         renderTotalSum={renderRowTotals && renderColumnTotals}

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.js
@@ -61,6 +61,9 @@ export const CategoryComboTableBody = React.memo(
         const nonNumberValueType = dataElements
             .map(({ valueType }) => valueType)
             .some((valueType) => !NUMBER_TYPES.includes(valueType))
+        const allNonNumberValueType = dataElements
+            .map(({ valueType }) => valueType)
+            .every((valueType) => !NUMBER_TYPES.includes(valueType))
 
         return (
             <TableBody
@@ -72,7 +75,7 @@ export const CategoryComboTableBody = React.memo(
                     categoryOptionCombos={sortedCOCs}
                     categories={categories}
                     renderRowTotals={renderRowTotals}
-                    nonNumberValueType={nonNumberValueType}
+                    allNonNumberValueType={allNonNumberValueType}
                     paddingCells={paddingCells}
                     checkTableActive={checkTableActive}
                 />
@@ -107,7 +110,7 @@ export const CategoryComboTableBody = React.memo(
                             ))}
                             {renderRowTotals && (
                                 <>
-                                    {!nonNumberValueType ? (
+                                    {NUMBER_TYPES.includes(de.valueType) ? (
                                         <RowTotal
                                             dataElements={dataElements}
                                             categoryOptionCombos={sortedCOCs}

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.js
@@ -71,7 +71,8 @@ export const CategoryComboTableBody = React.memo(
                 <CategoryComboTableBodyHeader
                     categoryOptionCombos={sortedCOCs}
                     categories={categories}
-                    renderRowTotals={renderRowTotals && !nonNumberValueType}
+                    renderRowTotals={renderRowTotals}
+                    nonNumberValueType={nonNumberValueType}
                     paddingCells={paddingCells}
                     checkTableActive={checkTableActive}
                 />
@@ -104,12 +105,21 @@ export const CategoryComboTableBody = React.memo(
                                     className={styles.tableCell}
                                 />
                             ))}
-                            {renderRowTotals && !nonNumberValueType && (
-                                <RowTotal
-                                    dataElements={dataElements}
-                                    categoryOptionCombos={sortedCOCs}
-                                    row={i}
-                                />
+                            {renderRowTotals && (
+                                <>
+                                    {!nonNumberValueType ? (
+                                        <RowTotal
+                                            dataElements={dataElements}
+                                            categoryOptionCombos={sortedCOCs}
+                                            row={i}
+                                        />
+                                    ) : (
+                                        <PaddingCell
+                                            key={i}
+                                            className={styles.tableCell}
+                                        />
+                                    )}
+                                </>
                             )}
                         </TableRow>
                     )
@@ -156,4 +166,9 @@ CategoryComboTableBody.propTypes = {
     renderRowTotals: PropTypes.bool,
 }
 
-const PaddingCell = () => <TableCell className={styles.paddingCell}></TableCell>
+const PaddingCell = () => (
+    <TableCell
+        className={styles.paddingCell}
+        dataTest="dhis2-dataentry-paddingcell"
+    ></TableCell>
+)

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.test.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.test.js
@@ -706,7 +706,7 @@ describe('<CategoryComboTableBody />', () => {
         const paddingCells = result.getAllByTestId(
             'dhis2-dataentry-paddingcell'
         )
-        expect(paddingCells.length).toBe(3)
+        expect(paddingCells.length).toBe(6)
     })
 
     it('should render the column totals when renderColumTotals = true', () => {
@@ -736,6 +736,34 @@ describe('<CategoryComboTableBody />', () => {
         expect(totalCells.length).toBe(1)
     })
 
+    it('should not render the column totals when renderColumTotals = true but value type is non-numeric', () => {
+        const tableDataElements = [{ ...dataElements.FTRrcoaog83 }]
+        tableDataElements[0].valueType = 'TEXT'
+
+        const result = render(
+            <Table>
+                <CategoryComboTableBody
+                    renderColumnTotals
+                    categoryCombo={categoryCombos.bjDvmb4bfuf}
+                    dataElements={tableDataElements}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const columnTotalsRow = result.queryByTestId(
+            'dhis2-dataentry-columntotals'
+        )
+        expect(columnTotalsRow).toBeNull()
+
+        const totalCells = result.queryAllByText('5', {
+            selector: '[data-test="dhis2-dataentry-totalcell"]',
+        })
+        expect(totalCells.length).toBe(0)
+    })
+
     it('should render the row totals when renderTowTotals = true', () => {
         const tableDataElements = [dataElements.FTRrcoaog83]
 
@@ -760,5 +788,34 @@ describe('<CategoryComboTableBody />', () => {
             'dhis2-dataentry-totalcell'
         )
         expect(totalCells).toBeTruthy()
+    })
+
+    it('should not render the row totals when renderTowTotals = true but value type is non-numeric', () => {
+        const tableDataElements = [{ ...dataElements.FTRrcoaog83 }]
+        tableDataElements[0].valueType = 'TEXT'
+
+        const result = render(
+            <Table>
+                <CategoryComboTableBody
+                    renderRowTotals
+                    categoryCombo={categoryCombos.bjDvmb4bfuf}
+                    dataElements={tableDataElements}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const inputRows = result.queryAllByTestId(
+            'dhis2-dataentry-tableinputrow'
+        )
+        expect(inputRows.length).toBe(1)
+
+        // it should render a padding cell that replaces the total cell (and one on header line)
+        const paddingCells = result.getAllByTestId(
+            'dhis2-dataentry-paddingcell'
+        )
+        expect(paddingCells.length).toBe(2)
     })
 })

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.test.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.test.js
@@ -26,6 +26,11 @@ const MOCK_VALUES = {
             value: '5',
         },
     },
+    FTRrcoaog83_NUMERIC: {
+        HllvX50cXC0: {
+            value: '150',
+        },
+    },
 }
 
 jest.mock('../../shared/stores/data-value-store.js', () => ({
@@ -817,5 +822,47 @@ describe('<CategoryComboTableBody />', () => {
             'dhis2-dataentry-paddingcell'
         )
         expect(paddingCells.length).toBe(2)
+    })
+
+    it('should not render row totals if value type is non-numeric and render row totals if value type is numeric', () => {
+        const tableDataElements = [
+            { ...dataElements.FTRrcoaog83 },
+            { ...dataElements.FTRrcoaog83 },
+        ]
+        tableDataElements[0].valueType = 'TEXT'
+        tableDataElements[1].id = 'FTRrcoaog83_NUMERIC'
+
+        const result = render(
+            <Table>
+                <CategoryComboTableBody
+                    renderRowTotals
+                    categoryCombo={categoryCombos.bjDvmb4bfuf}
+                    dataElements={tableDataElements}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const inputRows = result.queryAllByTestId(
+            'dhis2-dataentry-tableinputrow'
+        )
+        expect(inputRows.length).toBe(2)
+        const totalCells = getByTestId(
+            inputRows[1],
+            'dhis2-dataentry-totalcell'
+        )
+        expect(totalCells).toBeTruthy()
+        const totalCells_value = result.queryAllByText('150', {
+            selector: '[data-test="dhis2-dataentry-totalcell"]',
+        })
+        expect(totalCells_value.length).toBe(1)
+
+        // it should render a padding cell that replaces the total cell (and one on header line)
+        const paddingCells = result.getAllByTestId(
+            'dhis2-dataentry-paddingcell'
+        )
+        expect(paddingCells.length).toBe(1)
     })
 })

--- a/src/data-workspace/custom-form/custom-form.module.css
+++ b/src/data-workspace/custom-form/custom-form.module.css
@@ -1,5 +1,5 @@
 .customForm {
-    width: 100%;
+    inline-size: 100%;
 }
 
 .customForm table {

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -22,7 +22,7 @@
     padding: 8px;
     background-color: #fff;
     inline-size: max-content;
-    width: 100%;
+    inline-size: 100%;
 }
 
 .footer {


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-18640.

This ticket removes row/column totals if data element is of a non-numeric type (such that the total cannot be calculated).

**Before**
<img width="655" alt="image" src="https://github.com/user-attachments/assets/13ca2c60-b8cb-4284-a689-ac0df1a76ffa" />


**After**
<img width="639" alt="image" src="https://github.com/user-attachments/assets/ceb3738c-0ace-47c5-a9ce-b90fe3f1d63b" />

_note: if there is a mix of numeric and non-numeric value types, the row totals (but not column totals) will display_
<img width="653" alt="image" src="https://github.com/user-attachments/assets/e690b189-f465-4719-9271-83de330dc61e" />


**Testing:**
tested manually plus added some manual tests