### PR TITLE
fix: get all validation rules metadata [DHIS2-19591]

### DIFF
--- a/src/shared/validation/query-key-factory.js
+++ b/src/shared/validation/query-key-factory.js
@@ -37,6 +37,7 @@ export const getValidationMetaDataQueryKey = (datasetId) => {
                     'displayDescription',
                     'displayName',
                 ],
+                paging: false,
             },
         },
     ]


### PR DESCRIPTION
This fixes issue where metadata was missing for validation rules and hence the app crashed. See the ticket (https://dhis2.atlassian.net/browse/DHIS2-19591). I've added a comment with instructions on how to recreate scenario.

Obviously, if there are thousands of validation rules, using paging=false, is not great. On the other hand, the results from the validation run are not paginated, so if we're concerned about the payload size, we should probably review at some point both the validation results response and the fetching for validation rules metadata.