### PR TITLE
fix: replace non-td total cells

### DIFF
--- a/src/data-workspace/custom-form/custom-form-total-cell.js
+++ b/src/data-workspace/custom-form/custom-form-total-cell.js
@@ -54,3 +54,7 @@ export const CustomFormTotalCell = ({ dataElementId }) => {
 CustomFormTotalCell.propTypes = {
     dataElementId: PropTypes.string.isRequired,
 }
+
+export const replaceTotalCell = (dataElementId) => (
+    <CustomFormTotalCell dataElementId={dataElementId} />
+)

--- a/src/data-workspace/custom-form/parse-html-to-react.test.js
+++ b/src/data-workspace/custom-form/parse-html-to-react.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { CustomFormTotalCell } from './custom-form-total-cell.js'
+import { parseHtmlToReact } from './parse-html-to-react.js'
+
+describe('parseHtmlToReact', () => {
+    it('replaces total cells inside td elements', () => {
+        const htmlCode =
+            "<td><input id='totalRANDOMuid01' name='total' dataelementid='RANDOMuid01'/></td>"
+        const metadata = {}
+        const result = parseHtmlToReact(htmlCode, metadata)
+        expect(result).toEqual(
+            <CustomFormTotalCell dataElementId="RANDOMuid01" />
+        )
+    })
+    it('replaces total cells outside of elements', () => {
+        const htmlCode =
+            "<div><input id='totalRANDOMuid01' name='total' dataelementid='RANDOMuid01'/></div>"
+        const metadata = {}
+        const result = parseHtmlToReact(htmlCode, metadata)
+        expect(result).toEqual(
+            <div>
+                <CustomFormTotalCell dataElementId="RANDOMuid01" />
+            </div>
+        )
+    })
+})

--- a/src/data-workspace/custom-form/replace-input-node.js
+++ b/src/data-workspace/custom-form/replace-input-node.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { selectors } from '../../shared/index.js'
 import { DataEntryField } from '../data-entry-cell/index.js'
+import { replaceTotalCell } from './custom-form-total-cell.js'
 
 const INPUT_TYPES = {
     ENTRYFIELD: 'ENTRYFIELD',
@@ -29,6 +30,9 @@ export const replaceInputNode = (domNode, metadata) => {
     // TODO: This was already there when I started on this branch
     // Need to check with Kai what his intentions were with it.
     // const cellProps = getCellPropsByInputType(inputType)
+    if (inputType === INPUT_TYPES.TOTAL && domNode.attribs.dataelementid) {
+        return replaceTotalCell(domNode.attribs.dataelementid)
+    }
 
     if (inputType !== INPUT_TYPES.ENTRYFIELD) {
         return undefined

--- a/src/data-workspace/custom-form/replace-td-node.js
+++ b/src/data-workspace/custom-form/replace-td-node.js
@@ -1,11 +1,7 @@
 import { attributesToProps } from 'html-react-parser'
 import React from 'react'
 import { IndicatorTableCell } from '../indicators-table-body/indicator-table-cell.js'
-import { CustomFormTotalCell } from './custom-form-total-cell.js'
-
-const replaceTotalCell = (dataElementId) => (
-    <CustomFormTotalCell dataElementId={dataElementId} />
-)
+import { replaceTotalCell } from './custom-form-total-cell.js'
 
 const replaceIndicatorCell = (indicatorId, metadata) => {
     const {


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-18488

Our logic was only replacing total cells within custom forms when they were inside <td> elements and hence missed out when total cells were not inside a table.

**Testing**
Manual testing: created a data set and added ANC 1 data element. Then I defined a form with total cell outside of a table, e.g.

```
<div><div style="width:100px">ANC Fixed:&nbsp;<input id="fbfJHSPpUQD-pq2XI5kz2BY-val" name="entryfield" title="" value="" /></div>\n\n<div style="width:100px">ANC Outreach:&nbsp;<input id="fbfJHSPpUQD-PT59n8BQbqM-val" name="entryfield" title="" value="" /></div>\n\n<p><strong>ANC TOTAL:&nbsp;</strong><input dataelementid="fbfJHSPpUQD" id="totalfbfJHSPpUQD" name="total" readonly="readonly" title="" value="" /></p></div>
```
Automatic testing: I've just added a basic test where the custom form cells are replaced (but not rendered). Probably when we revisit custom form implementation, it might be useful to expand tests (there is very little test coverage here at the moment)
