### PR TITLE
fix: disabled fields in custom forms [DHIS2-19768]

### DIFF
--- a/src/data-workspace/custom-form/parse-html-to-react.test.js
+++ b/src/data-workspace/custom-form/parse-html-to-react.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { DataEntryField } from '../data-entry-cell/index.js'
 import { CustomFormTotalCell } from './custom-form-total-cell.js'
 import { parseHtmlToReact } from './parse-html-to-react.js'
 
@@ -20,6 +21,44 @@ describe('parseHtmlToReact', () => {
         expect(result).toEqual(
             <div>
                 <CustomFormTotalCell dataElementId="RANDOMuid01" />
+            </div>
+        )
+    })
+
+    it('uses disabled entry field when input has disabled attribute', () => {
+        const htmlCode =
+            "<div><input id='RANDOMuid01-randomCOC02-val' name='entryfield' title='A DE' val='[ A DE ]' disabled='disabled'/></div>"
+
+        const metadata = {
+            dataElements: { RANDOMuid01: { id: 'RANDOMuid01' } },
+        }
+        const result = parseHtmlToReact(htmlCode, metadata)
+        expect(result).toEqual(
+            <div>
+                <DataEntryField
+                    disabled={true}
+                    dataElement={{ id: 'RANDOMuid01' }}
+                    categoryOptionCombo={{ id: 'randomCOC02' }}
+                />
+            </div>
+        )
+    })
+
+    it('uses non disabled entry field when input does not have disabled attribute ', () => {
+        const htmlCode =
+            "<div><input id='RANDOMuid01-randomCOC02-val' name='entryfield' title='A DE' val='[ A DE ]'/></div>"
+
+        const metadata = {
+            dataElements: { RANDOMuid01: { id: 'RANDOMuid01' } },
+        }
+        const result = parseHtmlToReact(htmlCode, metadata)
+        expect(result).toEqual(
+            <div>
+                <DataEntryField
+                    disabled={false}
+                    dataElement={{ id: 'RANDOMuid01' }}
+                    categoryOptionCombo={{ id: 'randomCOC02' }}
+                />
             </div>
         )
     })

--- a/src/data-workspace/custom-form/replace-input-node.js
+++ b/src/data-workspace/custom-form/replace-input-node.js
@@ -39,11 +39,15 @@ export const replaceInputNode = (domNode, metadata) => {
     }
 
     const [deId, cocId] = domNode.attribs.id.split('-')
+    const disabled =
+        domNode.attribs.disabled === 'disabled' ||
+        domNode.attribs.disabled === 'true'
     const dataElement = selectors.getDataElementById(metadata, deId)
     return (
         <DataEntryField
             dataElement={dataElement}
             categoryOptionCombo={{ id: cocId }}
+            disabled={disabled}
         />
     )
 }


### PR DESCRIPTION
See: https://dhis2.atlassian.net/browse/DHIS2-19768

This disables cells marked with disabled property in custom forms.

**Before**
<img width="869" alt="image" src="https://github.com/user-attachments/assets/64e54727-a1b4-498c-aa68-af4ea0fd9ab3" />


**After**
<img width="862" alt="image" src="https://github.com/user-attachments/assets/26e9da90-379b-415a-b284-867f93a5bedc" />

Testing
I added some basic automated tests (just testing if DataEntryField gets disabled prop based on the original html)

_Sample metadata for manual testing_
You can metadata import this through import/export app on SL database, and then go to `00 - test - disabled` data set in data entry app:
[custom_form_disabled_fields.json](https://github.com/user-attachments/files/20868150/custom_form_disabled_fields.json)

