### PR TITLE
fix: totals calculation in custom form [DHIS2-19832]

### DIFF
--- a/src/data-workspace/custom-form/custom-form-total-cell.jsx
+++ b/src/data-workspace/custom-form/custom-form-total-cell.jsx
@@ -1,54 +1,34 @@
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
-import {
-    useBlurredField,
-    useValueStore,
-    useEntryFormStore,
-} from '../../shared/index.js'
+import { useValueStore } from '../../shared/index.js'
 import { TotalCell } from '../category-combo-table-body/total-cells.jsx'
-import { parseFieldId } from '../get-field-id.jsx'
 
-const computeTotal = (dataElementId, dataValues, formErrors) => {
-    const dataElementValues = dataValues?.[dataElementId] || {}
-
-    if (!dataElementValues) {
-        return null
-    }
-
+const computeTotalValues = (dataElementValues) => {
     // Initialise sum as null and only start counting when numerical values
     // are encountered to avoid rendering zeros when the sum isn't actually zero
-    return Object.entries(dataElementValues).reduce(
-        (sum, [cocId, valueDetails]) => {
-            const fieldHasError = formErrors?.[dataElementId]?.[cocId]
+    return Object.values(dataElementValues).reduce((sum, valueDetails) => {
+        const value = valueDetails?.value
 
-            const value = valueDetails?.value
-
-            if (!fieldHasError && !isNaN(value)) {
-                sum = isNaN(sum) ? value : sum + Number(value)
-            }
-            return sum
-        },
-        null
-    )
+        if (!isNaN(value)) {
+            sum = isNaN(sum) ? value : sum + Number(value)
+        }
+        return sum
+    }, null)
 }
 
 export const CustomFormTotalCell = ({ dataElementId }) => {
     const dataValues = useValueStore((state) => state.getDataValues())
-    const formErrors = useEntryFormStore((state) => state.getErrors())
+    const dataElementValues = dataValues?.[dataElementId] || {}
 
-    const blurredField = useBlurredField()
     const [total, setTotal] = useState(() =>
-        computeTotal(dataElementId, dataValues, formErrors)
+        computeTotalValues(dataElementValues)
     )
 
     useEffect(() => {
-        const { dataElementId: blurredFieldDataElementId } =
-            parseFieldId(blurredField)
-        if (blurredFieldDataElementId === dataElementId) {
-            setTotal(computeTotal(dataElementId, dataValues, formErrors))
-        }
-    }, [blurredField, dataElementId, dataValues, formErrors])
-
+        setTotal(() => {
+            return computeTotalValues(dataElementValues)
+        })
+    }, [dataElementValues])
     return <TotalCell>{total}</TotalCell>
 }
 CustomFormTotalCell.propTypes = {

--- a/src/data-workspace/custom-form/custom-form-total-cell.test.jsx
+++ b/src/data-workspace/custom-form/custom-form-total-cell.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { useValueStore } from '../../shared/stores/data-value-store.js'
+import { render } from '../../test-utils/index.js'
+import { CustomFormTotalCell } from './custom-form-total-cell.jsx'
+
+jest.mock('../../shared/stores/data-value-store.js', () => ({
+    ...jest.requireActual('../../shared/stores/data-value-store.js'),
+    useValueStore: jest.fn(),
+}))
+
+describe('CustomFormTotalCell', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('renders the sum of values (3)', () => {
+        useValueStore.mockReturnValueOnce({
+            testDE: { abc: { value: 1 }, xyz: { value: 2 } },
+        })
+        const result = render(<CustomFormTotalCell dataElementId="testDE" />)
+        expect(result.getByText('3')).toBeInTheDocument()
+    })
+
+    it('renders the sum of values (20)', () => {
+        useValueStore.mockReturnValueOnce({
+            testDE: { abc: { value: 15 }, xyz: { value: 5 } },
+        })
+        const result = render(<CustomFormTotalCell dataElementId="testDE" />)
+        expect(result.getByText('20')).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
This PR fixes an issue with the calculations in custom forms to make sure that they update on cell blur. See: https://dhis2.atlassian.net/browse/DHIS2-19832

### Example
See ticket for example of problematic behaviour. Here's a sample of the app after the update (totals recalculating on cell blur):
![mali_example_updated](https://github.com/user-attachments/assets/3eccd826-3330-460c-b62e-231a7cf5baf1)


### Technical notes

When looking at this issue, I observed that the component was getting the updated blurred cell, but that the data values from the update were not included, so then it did not calculate a new sum. Subsequently, on next blur, the logic in the data values were updated but the logic said a new sum should not be calculated as the cell had not been immediately blurred. 

I looked into keeping track of blur history, but I think that was a bit pointless. This does seem like a bit of a classic race condition and if we wanted to use the old logic, I guess we'd need to have the calculation performed on a callback when the optimistic update was made. I think it was easier to just update the useEffect to respond to changes in the subsection of dataValues relevant to a given data element (which zustand should keep stable).

### Testing
I wanted to ideally test this by actually simulating a user's input of values into the cells, but the setup for that proved a bit too much (I need to mock out CustomDataProvider values and some react-query set up). I think we probably should have a jest test of data-workspace, but for now I just added some test for the CustomFormTotalCell to make sure it gets the right value from the dataValues. I wanted to also change the hook value of the dataValues, but this seems to have been more difficult than I thought (I tried mocking the hook in various ways). I think that might be intentional though as it seems a bit incorrect to mock the change in the internal hook.