### PR TITLE
fix: update indicator recalculation logic [DHIS2-19832]

### DIFF
--- a/src/data-workspace/indicators-table-body/indicator-table-cell.jsx
+++ b/src/data-workspace/indicators-table-body/indicator-table-cell.jsx
@@ -2,7 +2,6 @@ import i18n from '@dhis2/d2-i18n'
 import { TableCell, Tooltip, IconInfo16, IconWarning16 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useBlurredField } from '../../shared/index.js'
 import styles from '../table-body.module.css'
 import {
     NONCALCULABLE_VALUE,
@@ -29,13 +28,11 @@ export const IndicatorTableCell = ({
     numerator,
     decimals,
 }) => {
-    const blurredField = useBlurredField()
     const {
         value: indicatorValue,
         numeratorValue,
         denominatorValue,
     } = useIndicatorValue({
-        blurredField,
         denominator,
         factor,
         numerator,

--- a/src/data-workspace/indicators-table-body/use-indicator-value.js
+++ b/src/data-workspace/indicators-table-body/use-indicator-value.js
@@ -18,7 +18,6 @@ import {
  * @returns {number} Indicator value
  */
 export const useIndicatorValue = ({
-    blurredField,
     denominator,
     factor,
     numerator,
@@ -43,33 +42,35 @@ export const useIndicatorValue = ({
         [denominator, numerator]
     )
 
+    const affectedValues = [...affectedDataElementsLookup]
+        .map((de) =>
+            Object.values(dataValues[de] ?? {})
+                .sort((a, b) =>
+                    a?.categoryOptionCombo?.localeCompare(
+                        b?.categoryOptionCombo
+                    )
+                )
+                .map((d) => d.value)
+        )
+        .flat()
+    const stringifiedValues = JSON.stringify(affectedValues)
+
     return useMemo(() => {
         /*
          * Only recompute the indicator value when a field related to
          * a data element in the indicator expression template is blurred.
          */
-        const { dataElementId } = parseFieldOperand(blurredField)
-        const containsAffectedDataElement =
-            affectedDataElementsLookup.has(dataElementId)
 
-        if (indicatorValueRef.current === null || containsAffectedDataElement) {
-            indicatorValueRef.current = computeIndicatorValue({
-                denominator,
-                numerator,
-                factor,
-                dataValues,
-                decimals,
-            })
-        }
+        indicatorValueRef.current = computeIndicatorValue({
+            denominator,
+            numerator,
+            factor,
+            dataValues,
+            decimals,
+        })
 
         return indicatorValueRef.current
-    }, [
-        affectedDataElementsLookup,
-        blurredField,
-        denominator,
-        factor,
-        dataValues,
-        numerator,
-        decimals,
-    ])
+    }, [stringifiedValues, denominator, numerator, factor, decimals])
+    // dependency array is non-exhaustive insofar as dataValues is excluded
+    // we check for only relevant changes in dataValues by using stringifiedValues
 }

--- a/src/data-workspace/indicators-table-body/use-indicator-value.test.js
+++ b/src/data-workspace/indicators-table-body/use-indicator-value.test.js
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react'
+import { useValueStore } from '../../shared/stores/data-value-store.js'
 import { computeIndicatorValue } from './compute-indicator-value.js'
 import { useIndicatorValue } from './use-indicator-value.js'
 
@@ -8,18 +9,54 @@ jest.mock('./compute-indicator-value.js', () => {
     return {
         __esModule: true,
         ...originalModule,
-        computeIndicatorValue: jest.fn(() => 10),
+        computeIndicatorValue: jest.fn(
+            ({ dataValues }) =>
+                (Number(dataValues.a.a1.value) +
+                    Number(dataValues.b.b1.value)) /
+                (Number(dataValues.c.c1.value) + Number(dataValues.d.d1.value))
+        ),
     }
 })
 
+jest.mock('../../shared/stores/data-value-store.js', () => {
+    return {
+        ...jest.requireActual('../../shared/stores/data-value-store.js'),
+        useValueStore: jest.fn(),
+    }
+})
+
+const dataValueSet = {
+    a: {
+        a1: {
+            categoryOptionCombo: 'a1',
+            value: '60',
+        },
+    },
+    b: {
+        b1: {
+            categoryOptionCombo: 'b1',
+            value: '80',
+        },
+    },
+    c: {
+        c1: {
+            categoryOptionCombo: 'c1',
+            value: '3',
+        },
+    },
+    d: {
+        d1: {
+            categoryOptionCombo: 'd1',
+            value: '4',
+        },
+    },
+}
+
 describe('useIndicatorValue hook', () => {
-    const mockForm = { getState: () => ({ values: {} }) }
     const initialProps = {
-        blurredField: undefined,
-        denominator: '#{d}*#{c}',
+        denominator: '#{d.d1}+#{c.c1}',
         factor: 100,
-        form: mockForm,
-        numerator: '#{a}+#{b.b1}*#{c.c1}',
+        numerator: '#{a.a1}+#{b.b1}',
     }
 
     beforeEach(() => {
@@ -27,72 +64,89 @@ describe('useIndicatorValue hook', () => {
     })
 
     it('should initialize the indicator value state correctly', () => {
+        useValueStore.mockReturnValue(dataValueSet)
+
         const { result } = renderHook(
-            ({ blurredField, denominator, factor, form, numerator }) =>
+            ({ denominator, factor, numerator }) =>
                 useIndicatorValue({
-                    blurredField,
                     denominator,
                     factor,
-                    form,
                     numerator,
                 }),
             {
                 initialProps,
             }
         )
-        expect(result.current).toBe(10)
+
+        expect(result.current).toBe(20)
         expect(computeIndicatorValue).toHaveBeenCalledTimes(1)
     })
 
     it('should not update the indicator value state if an unrelated field changes', () => {
+        useValueStore.mockReturnValue(dataValueSet)
+
         const { result, rerender } = renderHook(
-            ({ blurredField, denominator, factor, form, numerator }) =>
+            ({ denominator, factor, numerator }) =>
                 useIndicatorValue({
-                    blurredField,
                     denominator,
                     factor,
-                    form,
                     numerator,
                 }),
             {
                 initialProps,
             }
         )
-        rerender({
-            ...initialProps,
-            /*
-             * `z.z1` or `z` are not present as operands in the numerator or
-             * denominator expression template. So when this field is blurred
-             * the indicator value should not be recomputed.
-             */
-            blurredField: 'z.z1',
+
+        expect(result.current).toBe(20)
+        expect(computeIndicatorValue).toHaveBeenCalledTimes(1)
+
+        useValueStore.mockReturnValue({
+            ...dataValueSet,
+            z: { z1: { categoryOptionCombo: 'd1', value: '11' } },
         })
 
-        expect(result.current).toBe(10)
+        rerender({
+            ...initialProps,
+            /*
+             * `z.z1` are not present as operands in the numerator or
+             * denominator expression template. So when this field value is changed
+             * the indicator value should not be recomputed.
+             */
+        })
+
+        expect(result.current).toBe(20)
         expect(computeIndicatorValue).toHaveBeenCalledTimes(1)
     })
-    it('should update the indicator value state if an related field changes', () => {
+    it('should update the indicator value state if an related field changes', async () => {
+        useValueStore.mockReturnValue(dataValueSet)
+
         const { result, rerender } = renderHook(
-            ({ blurredField, denominator, factor, form, numerator }) =>
+            ({ denominator, factor, numerator }) =>
                 useIndicatorValue({
-                    blurredField,
                     denominator,
                     factor,
-                    form,
                     numerator,
                 }),
             {
                 initialProps,
             }
         )
+
+        expect(result.current).toBe(20)
+        expect(computeIndicatorValue).toHaveBeenCalledTimes(1)
+
+        useValueStore.mockReturnValue({
+            ...dataValueSet,
+            d: { d1: { categoryOptionCombo: 'd1', value: '11' } },
+        })
+
         rerender({
             ...initialProps,
             /*
-             * `d` is a data element operand in the denominator expression template
-             * `d.d1` is a field for a COC in that data element so this should
-             *  trigger a recomputation of the indicator value.
+             * `d.d1` are present as operands in the numerator or
+             * denominator expression template. So when this field value is changed
+             * the indicator value should be recomputed.
              */
-            blurredField: 'd.d1',
         })
 
         expect(result.current).toBe(10)


### PR DESCRIPTION
This is a follow up to https://dhis2.atlassian.net/browse/DHIS2-19832

The original ticket mentioned delays in totals calculation, but after fixing that, I noticed that there were also delays with indicator calculations in custom forms (I had my overly optimistic developer mindset of only paying attention to what I had been told was a bug  🙃

This PR updates the logic to check for changes in affected values relevant to an indicator, rather than relying on blurred field. As with the PR for totals (https://github.com/dhis2/aggregate-data-entry-app/pull/482), the issue appears to be an apparent race condition where dataValues state is updated after the blurred field is set, so when we use the data values associated with the blurred field we have stale data values (at least for custom forms).

### testing
did manual testing with both custom form (the one provided in the original ticket) and section form (I created an indicator that I added to Child Health form).
I've updated the existing automated tests to mimic an update to value returned from useDataValues and check that the calculation is occurring only when relevant value changes.

