### PR TITLE
fix: default to all sections [DHIS2-19909]

### DIFF
--- a/cypress/e2e/context-selection/section-filter/index.js
+++ b/cypress/e2e/context-selection/section-filter/index.js
@@ -124,7 +124,7 @@ Then('that section should be selected', () => {
 
 Then('the "all sections" option should be selected', () => {
     cy.get('[data-test="section-filter-selector"]')
-        .contains('Equipment')
+        .contains('All sections')
         .should('exist')
 })
 

--- a/src/context-selection/section-filter-selector-bar-item/section-filter-selector-bar-item.jsx
+++ b/src/context-selection/section-filter-selector-bar-item/section-filter-selector-bar-item.jsx
@@ -28,7 +28,11 @@ export default function SectionFilterSelectorBarItem() {
 
     useEffect(() => {
         const sections = dataSet?.sections
-        if (sectionFilter === undefined && sections?.length) {
+        if (
+            dataSet?.renderAsTabs &&
+            sectionFilter === undefined &&
+            sections?.length
+        ) {
             setSectionFilter(sections[0].id)
         }
         // clear out section if it is invalid
@@ -54,7 +58,7 @@ export default function SectionFilterSelectorBarItem() {
 
     const selectableOptions = dataSet?.renderAsTabs
         ? sectionOptions
-        : [...sectionOptions, { value: null, label: i18n.t('All sections') }]
+        : [{ value: null, label: i18n.t('All sections') }, ...sectionOptions]
 
     return (
         <div data-test="section-filter-selector">
@@ -67,7 +71,7 @@ export default function SectionFilterSelectorBarItem() {
             >
                 <MenuSelect
                     values={selectableOptions}
-                    selected={sectionFilter}
+                    selected={sectionFilter ?? null}
                     onChange={({ selected }) => {
                         setSectionFilter(selected)
                         setOpen(false)


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-19909

This PR essentially reverses this work https://dhis2.atlassian.net/browse/DHIS2-18405. We had implemented a change to display first section by default as a workaround for rendering performance issues for large forms. We have now improved app performance by eliminating react-final-form dependency, so we should be able to safely go back to the old approach of showing "All sections" by default (https://dhis2.atlassian.net/browse/DHIS2-18373)