### PR TITLE
fix: deleted audit no value

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-09-16T12:04:32.693Z\n"
-"PO-Revision-Date: 2025-09-16T12:04:32.694Z\n"
+"POT-Creation-Date: 2025-10-01T10:47:43.465Z\n"
+"PO-Revision-Date: 2025-10-01T10:47:43.465Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -359,6 +359,9 @@ msgstr "audit dates are given in {{- timeZone}} time"
 
 msgid "log displays only changes made while audit was enabled"
 msgstr "log displays only changes made while audit was enabled"
+
+msgid "Deleted"
+msgstr "Deleted"
 
 msgid "Unmark for follow-up"
 msgstr "Unmark for follow-up"

--- a/src/data-workspace/data-details-sidebar/audit-log.jsx
+++ b/src/data-workspace/data-details-sidebar/audit-log.jsx
@@ -180,11 +180,18 @@ AuditLog.propTypes = {
 }
 
 function DeletedValue({ value }) {
+    if (value) {
+        return (
+            <div className={styles.alignToEnd}>
+                <Tag negative className={styles.lineThrough}>
+                    {value}
+                </Tag>
+            </div>
+        )
+    }
     return (
         <div className={styles.alignToEnd}>
-            <Tag negative className={styles.lineThrough}>
-                {value}
-            </Tag>
+            <Tag negative>{i18n.t('Deleted')}</Tag>
         </div>
     )
 }

--- a/src/data-workspace/data-details-sidebar/audit-log.test.jsx
+++ b/src/data-workspace/data-details-sidebar/audit-log.test.jsx
@@ -96,6 +96,11 @@ describe('<AuditLog />', () => {
                 modifiedBy: 'Firstname3 Lastname3',
                 value: '19',
             },
+            {
+                auditType: 'DELETE',
+                created: new Date('2021-01-01').toISOString(),
+                modifiedBy: 'Firstname4 Lastname4',
+            },
         ]
 
         const data = { audits }
@@ -144,6 +149,9 @@ describe('<AuditLog />', () => {
         const thirdChangeValue = within(auditRows[3]).getByText('19', {})
         expect(thirdChangeValue).toBeInTheDocument()
         expect(auditRows[3].textContent).toContain('→19')
+
+        // expect a DELETED audit without value to show deleted
+        expect(auditRows[4].textContent).toContain('Deleted')
 
         // check that note about time zone appears
         expect(


### PR DESCRIPTION
This fixes an issue with audits. New updated audit log from backend is not returning a value for DELETED audit items. We expected a value, and we showed the crossed out value.

This PR updates the logic to show the tag with text "Deleted" in cause the deleted audit item does not have a value

<img width="279" height="335" alt="image" src="https://github.com/user-attachments/assets/433dba00-6cc3-4827-bb57-1562dd02be89" />

Note: I've left handling in case there is a value because older versions have that and we might add this back on the backend (pending discussion) 
