### PR TITLE
fix: show delete limits button [DHIS2-19517]

### DIFF
--- a/src/data-workspace/data-details-sidebar/limits.jsx
+++ b/src/data-workspace/data-details-sidebar/limits.jsx
@@ -8,6 +8,7 @@ import {
     useUnsavedDataStore,
     useContextSelectionId,
     getCellId,
+    useFeatureToggleContext,
 } from '../../shared/index.js'
 import { useMinMaxLimits } from '../use-min-max-limits.js'
 import LimitsDisplay from './limits-display.jsx'
@@ -20,6 +21,7 @@ export default function Limits({ dataValue }) {
     const [open, setOpen] = useState(true)
     const [editing, setEditing] = useState(false)
     const contextSelectionId = useContextSelectionId()
+    const { minMaxDeleteAuthorityExists } = useFeatureToggleContext()
 
     const cellId = getCellId({ item: dataValue, contextSelectionId })
     const unsavedLimits = useUnsavedDataStore((state) => {
@@ -34,7 +36,10 @@ export default function Limits({ dataValue }) {
 
     const { data: userInfo } = useUserInfo()
 
-    const canDelete = userInfoSelectors.getCanDeleteMinMax(userInfo)
+    const canDelete = userInfoSelectors.getCanDeleteMinMax(
+        userInfo,
+        minMaxDeleteAuthorityExists
+    )
     const canAdd = userInfoSelectors.getCanAddMinMax(userInfo)
 
     useEffect(() => {

--- a/src/data-workspace/data-details-sidebar/limits.test.jsx
+++ b/src/data-workspace/data-details-sidebar/limits.test.jsx
@@ -1,9 +1,15 @@
+import { useConfig } from '@dhis2/app-runtime'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { useUserInfo, useCanUserEditFields } from '../../shared/index.js'
 import { render } from '../../test-utils/index.js'
 import { useMinMaxLimits } from '../use-min-max-limits.js'
 import Limits from './limits.jsx'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    useConfig: jest.fn(),
+}))
 
 jest.mock('../use-min-max-limits.js', () => ({
     useMinMaxLimits: jest.fn(),
@@ -28,6 +34,9 @@ describe('<Limits />', () => {
                     authorities: ['ALL'],
                 },
             }))
+            useConfig.mockReturnValue({
+                serverVersion: { major: 2, minor: 43, patch: undefined },
+            })
         })
 
         it('is expanded by default', () => {
@@ -75,6 +84,97 @@ describe('<Limits />', () => {
         })
     })
 
+    describe('shows delete limits button based on version-dependent authorities', () => {
+        beforeAll(() => {
+            useMinMaxLimits.mockReturnValue({ min: 3, max: 4 })
+        })
+
+        it('shows delete button in v43 if user has F_MINMAX_DATAELEMENT_ADD authority', async () => {
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: ['F_MINMAX_DATAELEMENT_ADD'],
+                },
+            }))
+            useConfig.mockReturnValue({
+                serverVersion: { major: 2, minor: 43, patch: undefined },
+            })
+            const { getByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            expect(
+                getByRole('button', { name: 'Edit limits' })
+            ).toBeInTheDocument()
+            expect(
+                getByRole('button', { name: 'Delete limits' })
+            ).toBeInTheDocument()
+        })
+
+        it('does not show delete button in v40 if user only has F_MINMAX_DATAELEMENT_ADD authority', async () => {
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: ['F_MINMAX_DATAELEMENT_ADD'],
+                },
+            }))
+            useConfig.mockReturnValue({
+                serverVersion: { major: 2, minor: 40, patch: undefined },
+            })
+            const { getByRole, queryByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            expect(
+                getByRole('button', { name: 'Edit limits' })
+            ).toBeInTheDocument()
+            expect(queryByRole('button', { name: 'Delete limits' })).toBeNull()
+        })
+
+        it('shows delete button in v40 if user has F_MINMAX_DATAELEMENT_DELETE authority', async () => {
+            useUserInfo.mockImplementation(() => ({
+                data: {
+                    authorities: [
+                        'F_MINMAX_DATAELEMENT_ADD',
+                        'F_MINMAX_DATAELEMENT_DELETE',
+                    ],
+                },
+            }))
+            useConfig.mockReturnValue({
+                serverVersion: { major: 2, minor: 43, patch: undefined },
+            })
+            const { getByRole } = render(
+                <Limits
+                    dataValue={{
+                        canHaveLimits: true,
+                        categoryOptionCombo: 'cat-combo-id',
+                        dataElement: 'de-id',
+                        valueType: 'INTEGER',
+                    }}
+                />
+            )
+
+            expect(
+                getByRole('button', { name: 'Edit limits' })
+            ).toBeInTheDocument()
+            expect(
+                getByRole('button', { name: 'Delete limits' })
+            ).toBeInTheDocument()
+        })
+    })
+
     describe('when has no limits to render', () => {
         beforeAll(() => {
             useMinMaxLimits.mockReturnValue({})
@@ -83,6 +183,9 @@ describe('<Limits />', () => {
                     authorities: ['ALL'],
                 },
             }))
+            useConfig.mockReturnValue({
+                serverVersion: { major: 2, minor: 43, patch: undefined },
+            })
         })
         it(`is disabled if value of itemType prop is not 'numerical'`, () => {
             const { getByText } = render(

--- a/src/shared/feature-toggle/use-feature-toggle-context.js
+++ b/src/shared/feature-toggle/use-feature-toggle-context.js
@@ -19,5 +19,6 @@ export function useFeatureToggleContext() {
     return {
         utilizeGistApiForPrefetchedOrganisationUnits:
             shouldUtilizeGistApiForPrefetchedOrganisationUnits(serverVersion),
+        minMaxDeleteAuthorityExists: serverVersion?.minor <= 40,
     }
 }

--- a/src/shared/feature-toggle/use-feature-toggle-context.test.js
+++ b/src/shared/feature-toggle/use-feature-toggle-context.test.js
@@ -33,4 +33,25 @@ describe('useFeatureToggle', () => {
             ).toBe(outcome)
         }
     )
+    it.each([
+        [false, { major: 2, minor: 43, patch: undefined }],
+        [false, { major: 2, minor: 43, patch: 0 }],
+        [false, { major: 2, minor: 43, patch: 3 }],
+        [false, { major: 2, minor: 42, patch: 2 }],
+        [false, { major: 2, minor: 42, patch: 1 }],
+        [false, { major: 2, minor: 41, patch: 5 }],
+        [false, { major: 2, minor: 41, patch: 6 }],
+        [false, { major: 2, minor: 41, patch: 4 }],
+        [true, { major: 2, minor: 40, patch: 9 }],
+        [true, { major: 2, minor: 40, patch: 11 }],
+        [true, { major: 2, minor: 40, patch: 8 }],
+    ])(
+        'sets minMaxDeleteAuthorityExists to %s when server version is %s',
+        async (outcome, serverVersion) => {
+            useConfig.mockReturnValue({ serverVersion })
+            const { result } = renderHook(() => useFeatureToggleContext())
+            expect(result.current).toHaveProperty('minMaxDeleteAuthorityExists')
+            expect(result.current.minMaxDeleteAuthorityExists).toBe(outcome)
+        }
+    )
 })

--- a/src/shared/use-user-info/user-info-selectors.js
+++ b/src/shared/use-user-info/user-info-selectors.js
@@ -6,9 +6,14 @@ const EDIT_EXPIRED = 'F_EDIT_EXPIRED'
 
 export const getAuthorities = (userInfo) => userInfo.authorities
 
-export const getCanDeleteMinMax = (userInfo) =>
+export const getCanDeleteMinMax = (userInfo, minMaxDeleteAuthorityExists) =>
     userInfo.authorities.some((auth) =>
-        [DELETE_MIN_MAX_AUTHORITY, ALL_AUTHORITY].includes(auth)
+        [
+            minMaxDeleteAuthorityExists
+                ? DELETE_MIN_MAX_AUTHORITY
+                : ADD_MIN_MAX_AUTHORITY,
+            ALL_AUTHORITY,
+        ].includes(auth)
     )
 
 export const getCanAddMinMax = (userInfo) =>


### PR DESCRIPTION
This PR updates the logic to show "Delete limits" button if F_MINMAX_DATAELEMENT_ADD is present (v41+)

So for admin user, this again show "Delete limits":

<img width="213" height="150" alt="image" src="https://github.com/user-attachments/assets/2f951210-55ed-4287-bc8e-2170990209d1" />
