### PR TITLE
fix: useHighlightedFieldStore coc logic [DHIS2-20741]

### DIFF
--- a/src/shared/highlighted-field/use-highlighted-field.js
+++ b/src/shared/highlighted-field/use-highlighted-field.js
@@ -17,19 +17,16 @@ function gatherHighlightedFieldData({
     const canHaveLimits = optionSet
         ? false
         : CAN_HAVE_LIMITS_TYPES.includes(valueType)
-    const categoryCombo = selectors.getCategoryComboById(
-        metadata,
-        dataElement.categoryCombo.id
-    )
-    const categoryOptionCombo = selectors.getCategoryOptionCombo(
-        metadata,
-        categoryCombo.id,
-        categoryOptionComboId
-    )
 
-    const categoryOptionComboName = categoryCombo.isDefault
+    const categoryOptionCombo =
+        selectors.getCategoryOptionComboByCategoryOptionComboId(
+            metadata,
+            categoryOptionComboId
+        )
+
+    const categoryOptionComboName = categoryOptionCombo?.isDefault
         ? ''
-        : categoryOptionCombo.displayName
+        : categoryOptionCombo?.displayName
 
     if (dataValue) {
         return {

--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -683,3 +683,41 @@ export const getDataSetsByOrgUnitId = createCachedSelector(
             )
         )
 )((_, organisationUnitId) => organisationUnitId)
+
+/**
+ * @param {*} metadata
+ */
+export const getCategoryOptionCombosMap = createSelector(
+    getCategoryCombos,
+    (categoryCombos) => {
+        const arrayOfCoCs = Object.values(categoryCombos ?? []).flatMap(
+            (categoryCombo) => {
+                const categoryOptionCombos =
+                    categoryCombo?.categoryOptionCombos ?? []
+
+                return categoryOptionCombos.map(({ id, displayName }) => [
+                    id,
+                    {
+                        id,
+                        displayName,
+                        isDefault: categoryCombo?.isDefault,
+                    },
+                ])
+            }
+        )
+
+        return Object.fromEntries(arrayOfCoCs)
+    }
+)
+
+/**
+ * @param {*} metadata
+ * @param {string} organisationUnitId
+ */
+export const getCategoryOptionComboByCategoryOptionComboId =
+    createCachedSelector(
+        getCategoryOptionCombosMap,
+        (_, categoryOptionComboId) => categoryOptionComboId,
+        (categoryOptionCombosMap, categoryOptionComboId) =>
+            categoryOptionCombosMap?.[categoryOptionComboId]
+    )((_, categoryOptionComboId) => categoryOptionComboId)

--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -18,6 +18,7 @@ import {
     getCategoryCombos,
     getCategoryOptionById,
     getCategoryOptionCombosByCategoryComboId,
+    getCategoryOptionComboByCategoryOptionComboId,
     getCategoryOptions,
     getCategoryOptionsByCategoryId,
     getCategoryOptionsByCategoryOptionComboId,
@@ -481,6 +482,52 @@ describe('getCategoryOptionCombosByCategoryComboId', () => {
         expect(
             getCategoryOptionCombosByCategoryComboId(data, categoryComboId)
         ).toBeNull()
+    })
+})
+
+describe('getCategoryOptionComboByCategoryOptionComboId', () => {
+    it('returns the expected data', () => {
+        const categoryComboId = 'categoryComboId'
+        const categoryOptionCombo = {
+            id: 'id',
+            displayName: 'my category optionCombo',
+        }
+        const data = {
+            categoryCombos: {
+                [categoryComboId]: {
+                    categoryOptionCombos: [categoryOptionCombo],
+                    isDefault: false,
+                },
+            },
+        }
+        const expected = { ...categoryOptionCombo, isDefault: false }
+
+        expect(
+            getCategoryOptionComboByCategoryOptionComboId(
+                data,
+                categoryOptionCombo.id
+            )
+        ).toEqual(expected)
+    })
+
+    it('returns undefined if there is no categoryOptionCombo', () => {
+        const categoryComboId = 'categoryComboId'
+        const categoryOptionCombo = {
+            id: 'id',
+            displayName: 'my category optionCombo',
+        }
+        const data = {
+            categoryCombos: {
+                [categoryComboId]: {
+                    categoryOptionCombos: [categoryOptionCombo],
+                    isDefault: false,
+                },
+            },
+        }
+
+        expect(
+            getCategoryOptionComboByCategoryOptionComboId(data, 'invalid_id')
+        ).toBeUndefined()
     })
 })
 


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-20741

There was a logic error when retrieving category option combo name for details. We tried to first get the category combo from the data element and then look up the category option combo information related to the category combo. This does not account for the fact that data set elements can have override category combos, so we cannot retrieve the category combo from the data element definition.

This makes an update to add a metadata selector that maps categoryOptionCombo ids: category option combos (this is a memoized selector, so should be acceptable performance wise) and then looks up category option combo details from there. I also considered updating highlighted field store to pass the category combo associated with the data element, but that requires more significant refactoring.