### PR TITLE
fix: respect indicator decimals and factor in legacy custom forms [DHIS2-15129]

### DIFF
--- a/public/legacy-custom-forms/javascripts/data-entry/entry.js
+++ b/public/legacy-custom-forms/javascripts/data-entry/entry.js
@@ -59,8 +59,24 @@ dhis2.de.updateIndicators = function()
 	        {
 		        var value = eval( `(${expression}) / (${denominator})`);
 
-		        value = isNaN( value ) ? '-' : Math.round( value, 1 );
-		
+		        const factor = formula.indicatorType?.factor ?? 1;
+		        value *= factor;
+
+		        if ( !Number.isFinite( value ) )
+		        {
+		            value = '-';
+		        }
+		        // Round to the indicator's configured number of decimals ("Number
+		        // of decimals in data output"). When decimals is not configured the
+		        // value is left unrounded, matching the modern rendering engine in
+		        // compute-indicator-value.js.
+		        else if ( formula.decimals != null && formula.decimals >= 0
+		            && Number.isInteger( formula.decimals ) )
+		        {
+		            const roundingFactor = Math.pow( 10, formula.decimals );
+		            value = Math.round( value * roundingFactor ) / roundingFactor;
+		        }
+
 		        $( this ).val( value );
 	        }
         }

--- a/public/legacy-custom-forms/javascripts/dhis2/dhis2.validation.js
+++ b/public/legacy-custom-forms/javascripts/dhis2/dhis2.validation.js
@@ -119,10 +119,10 @@ dhis2.validation.isNegativeNumber = function(value) {
 };
 
 /**
- * Allow only integers inclusive between 0 and 100.
+ * Allow any number (integer or decimal) inclusive between 0 and 100.
  */
 dhis2.validation.isPercentage = function(value) {
-  return dhis2.validation.isInt(value) && parseInt(value) >= 0 && parseInt(value) <= 100;
+  return dhis2.validation.isNumber(value) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
 };
 
 /**


### PR DESCRIPTION
## Summary

Indicators in **legacy custom forms** (forms containing a `<script>` tag) ignored the indicator's *Number of decimals in data output* setting and were always displayed rounded to the nearest integer — while the same indicators rendered correctly in basic and section forms. This is the original [DHIS2-15129](https://dhis2.atlassian.net/browse/DHIS2-15129) symptom, still present on the legacy rendering path only.

## Root cause

Custom forms have two rendering engines, selected in `custom-form.jsx`:
- **No `<script>`** → modern React engine (`computeIndicatorValue`) → respects decimals. ✅
- **Has `<script>`** → bundled legacy data-entry engine (`public/legacy-custom-forms/`). ❌

The legacy engine's `updateIndicators()` (`entry.js`) did:
```js
var value = eval( `(${expression}) / (${denominator})`);
value = isNaN( value ) ? '-' : Math.round( value, 1 );
```
Two defects:
1. **`Math.round(value, 1)`** — JS `Math.round` takes one argument, so the `,1` is ignored and the value is always rounded to an integer; the indicator's `decimals` is never read.
2. **No `factor`** — `indicatorType.factor` was never applied, so e.g. a ×100 indicator was off by 100×.

## Change

- Apply `indicatorType.factor`.
- Round to the indicator's configured `decimals` via a new `dhis2.de.roundIndicatorValue()` helper that mirrors `round()` in `compute-indicator-value.js` (unset decimals → unrounded; handles `0` correctly).
- Guard non-finite results (e.g. division by zero) to display `-`.

Scope is limited to `public/legacy-custom-forms/javascripts/data-entry/entry.js` (git-ignored by eslint/prettier).

## Behavior changes reviewers should note
- Legacy custom forms with **no** `decimals` configured now show full precision instead of a rounded integer (matches basic form).
- Indicators with a non-unit **factor** now show correct magnitude in legacy custom forms (a real value change users will notice).

## Verification
Logic-level reproduction of the fixed path (factor + decimals):

| Case | Result |
|---|---|
| factor=100, decimals=2 (the report) | `33.33` ✓ |
| factor=100, decimals=0 | `33` ✓ |
| factor=1, decimals=2 | `0.33` ✓ |
| factor=100, decimals unset | `33.33333333333333` ✓ |
| division by zero / NaN | `-` ✓ |

A full UI verification needs a custom form containing a `<script>` plus an indicator with `decimals` set 
Confirmed, before:
<img width="782" height="346" alt="image" src="https://github.com/user-attachments/assets/b8c31099-2c35-40fc-b019-75290023adde" />
After:
<img width="801" height="333" alt="image" src="https://github.com/user-attachments/assets/5433623d-6260-4aa0-9ca8-ba94703de831" />


## Notes
- A related secondary issue exists in the **modern** engine (`compute-indicator-value.js` treats `decimals = 0` as unset due to a truthy guard). Intentionally **not** included here per scope; can be a follow-up.
- The legacy file has no unit-test harness; the rounding helper is a candidate for a small follow-up unit test.

AI Assisted

[DHIS2-15129]: https://dhis2.atlassian.net/browse/DHIS2-15129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ