### PR TITLE
fix: respect indicator decimals and factor in legacy custom forms 

### DIFF
--- a/public/legacy-custom-forms/javascripts/data-entry/entry.js
+++ b/public/legacy-custom-forms/javascripts/data-entry/entry.js
@@ -59,8 +59,24 @@ dhis2.de.updateIndicators = function()
 	        {
 		        var value = eval( `(${expression}) / (${denominator})`);
 
-		        value = isNaN( value ) ? '-' : Math.round( value, 1 );
-		
+		        const factor = formula.indicatorType?.factor ?? 1;
+		        value *= factor;
+
+		        if ( !Number.isFinite( value ) )
+		        {
+		            value = '-';
+		        }
+		        // Round to the indicator's configured number of decimals ("Number
+		        // of decimals in data output"). When decimals is not configured the
+		        // value is left unrounded, matching the modern rendering engine in
+		        // compute-indicator-value.js.
+		        else if ( formula.decimals != null && formula.decimals >= 0
+		            && Number.isInteger( formula.decimals ) )
+		        {
+		            const roundingFactor = Math.pow( 10, formula.decimals );
+		            value = Math.round( value * roundingFactor ) / roundingFactor;
+		        }
+
 		        $( this ).val( value );
 	        }
         }


### PR DESCRIPTION
[DHIS2-15129]

Legacy custom forms (those containing a <script> tag) are rendered by the bundled old data-entry engine instead of the modern React engine. Its updateIndicators() used Math.round(value, 1) - the second argument is ignored by Math.round, so indicator values were always rounded to the nearest integer - and it never applied the indicator type factor.

As a result an indicator configured with e.g. 2 decimals displayed as a rounded integer in custom forms while showing correctly in the basic and section forms. This is the original DHIS2-15129 symptom, still present on the legacy path only.

Apply indicatorType.factor and round to the indicator's configured number of decimals inline in updateIndicators(). When decimals is not configured the value is left unrounded, matching the modern rendering engine in compute-indicator-value.js.

Verified end-to-end against EPI Stock (BCG Stock PHU, decimals=2): entering 5.567 now renders 5.57 instead of 6.

AI Assisted

[DHIS2-15129]: https://dhis2.atlassian.net/browse/DHIS2-15129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ