### PR TITLE
fix: allow decimals for value type percentage in legacy custom forms [DHIS2-13645]

### DIFF
--- a/public/legacy-custom-forms/javascripts/dhis2/dhis2.validation.js
+++ b/public/legacy-custom-forms/javascripts/dhis2/dhis2.validation.js
@@ -119,10 +119,10 @@ dhis2.validation.isNegativeNumber = function(value) {
 };
 
 /**
- * Allow only integers inclusive between 0 and 100.
+ * Allow any number (integer or decimal) inclusive between 0 and 100.
  */
 dhis2.validation.isPercentage = function(value) {
-  return dhis2.validation.isInt(value) && parseInt(value) >= 0 && parseInt(value) <= 100;
+  return dhis2.validation.isNumber(value) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
 };
 
 /**

--- a/public/legacy-custom-forms/javascripts/dhis2/dhis2.validation.js
+++ b/public/legacy-custom-forms/javascripts/dhis2/dhis2.validation.js
@@ -122,7 +122,7 @@ dhis2.validation.isNegativeNumber = function(value) {
  * Allow any number (integer or decimal) inclusive between 0 and 100.
  */
 dhis2.validation.isPercentage = function(value) {
-  return dhis2.validation.isNumber(value) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
+  return dhis2.validation.isNumber(value) && Number.parseFloat(value) >= 0 && Number.parseFloat(value) <= 100;
 };
 
 /**


### PR DESCRIPTION
## Summary

Custom (legacy) forms rejected decimal values for `PERCENTAGE` data elements, even though the backend accepts them. This makes the legacy custom-forms validator match the backend and the modern React entry path.

[DHIS2-13645](https://dhis2.atlassian.net/browse/DHIS2-13645)

## Root cause

`dhis2.validation.isPercentage` validated via `isInt`/`parseInt`, restricting percentage to integers and rejecting valid values such as `50.5`.

## Change

Validate via the existing `isNumber` helper + `parseFloat` within `[0, 100]`:

```js
dhis2.validation.isPercentage = function(value) {
  return dhis2.validation.isNumber(value) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
};
```

This matches:
- **Backend** — `MathUtils.isPercentage`: numeric `Double` in range `[0, 100]`.
- **Modern React entry path** — `createNumberRange(0, 100)` (no integer restriction).

Single definition, used by all call sites (`entry.js`, the type switch in `dhis2.validation.js`, `covid-form.html`).

Out of scope (intentional): PERCENTAGE min/max **limits** stay integer-only, as the backend restricts those to integers.

## Testing

Ran the actual shipped validator against test cases:
- Now valid: `50.5`, `0.1`, `99.999`, plus integers `0`, `50`, `100`.
- Still rejected: `100.5`, `-1`, `-0.5`, `abc`, ``, `.5`, `50.`, `1,000`.

AI Assisted

[DHIS2-13645]: https://dhis2.atlassian.net/browse/DHIS2-13645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ