### PR TITLE
chore: remove obsolete styled-jsx eslint rule [DHIS2-14514]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,4 @@ const { config } = require('@dhis2/cli-style')
 
 module.exports = {
     extends: [config.eslintReact, 'plugin:cypress/recommended'],
-    // TODO: remove this rule when styled-jsx is removed from the app
-    // https://dhis2.atlassian.net/browse/DHIS2-14514
-    rules: { 'react/no-unknown-property': ['error', { ignore: ['jsx'] }] },
 }


### PR DESCRIPTION
## Summary

Removes the now-obsolete `react/no-unknown-property` ESLint override that ignored the `jsx` prop, completing [DHIS2-14514](https://dhis2.atlassian.net/browse/DHIS2-14514).

`styled-jsx` (`<style jsx>`) has already been removed from the app in favour of CSS modules — the Organisation Unit Tree components (the last remaining users, flagged in the ticket back in 2023) now use `*.module.css`. A repo-wide search confirms there are no `<style jsx>` usages or `jsx` props left in `src/`, and `styled-jsx` is no longer a direct dependency (it appears only transitively via `@dhis2/ui` and `@dhis2/cli-style`, which is the intended location).

With no `jsx` props remaining, the ESLint ignore rule — and its TODO comment pointing at this ticket — is dead code.

## Changes
- `.eslintrc.js`: removed the `rules: { 'react/no-unknown-property': ['error', { ignore: ['jsx'] }] }` override and its TODO comment.

## Testing
- Ran ESLint over `src/**/*.{js,jsx}` after the change: **no `react/no-unknown-property` errors**, confirming nothing relied on the override. (Remaining lint output is pre-existing and unrelated: `import/no-unresolved` for build-time-generated `locales/index.js`, and two pre-existing `react-hooks/exhaustive-deps` warnings.)

AI Assisted

[DHIS2-14514]: https://dhis2.atlassian.net/browse/DHIS2-14514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ