### PR TITLE
fix: render org unit tree when gist prefetch API is enabled

### DIFF
--- a/src/context-selection/org-unit-selector-bar-item/use-prefetched-organisation-units.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-prefetched-organisation-units.js
@@ -49,12 +49,12 @@ const createGistPrefetchQueryArgs = ([path, offlineLevels]) => ({
     ],
     enabled: Boolean(path && offlineLevels?.length >= 1),
     select: (results) =>
-        results.organisationUnits.map(({ displayName, path, children }) => ({
+        results.organisationUnits.map(({ name: displayName, path, children }) => ({
             displayName,
             id: path.split('/').at(-1),
             path,
             children: children ? 1 : 0,
-            level: path.split('/').length,
+            level: path.split('/').length - 1,
         })),
 })
 


### PR DESCRIPTION
When the `utilizeGistApiForPrefetchedOrganisationUnits` feature toggle is on, `createGistPrefetchQueryArgs` mapped the gist response incorrectly, leaving the org unit tree in the Organisation unit selector rendering blank rows with `undefined` props for every user (with a `[re-reselect] Invalid cache key "undefined" has been returned by keySelector function` warning on every load). This blocks all data entry through the UI.

Two bugs, both in the `select()` mapping:

First, `level` was computed as `path.split('/').length`, which is off by one because DHIS2 org unit paths have a leading `/`. That mismatched `offlineLevels` (derived from the real API `level` field), so tree rows never matched the fetched org units. Fixed by subtracting 1.

Second, the gist endpoint returns `name`, not `displayName` (unlike `/api/organisationUnits.json`), so labels were permanently blank once the level fix was applied. Fixed by destructuring `name` as `displayName`.

To reproduce: enable the toggle (calls to `/api/{version}/organisationUnits/gist?orgUnitsOffline=true...` appear in the network tab), open the Data Entry app, and click the Organisation unit selector — the tree comes up empty.

Tested by rebuilding the app from source with both one-liners applied: the org unit tree then renders and is selectable (DHIS2 core 2.41.0, app v102.0.10, single-facility org unit hierarchy).

Reported and diagnosed here: https://community.dhis2.org/t/data-entry-app-aggregate-data-entry-v102-0-10-organisation-unit-tree-renders-blank-rows-with-undefined-props-for-all-users/75375