### PR TITLE
feat: totals for pivoted layout [DHIS2-19079]

### DIFF
--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
@@ -149,8 +149,8 @@ export const PivotedCategoryComboTableBody = React.memo(
                                                         'dataElement',
                                                 }
                                             )}
-                                            colSpan={fieldInRow.colSpan}
-                                            rowSpan={fieldInRow.rowSpan}
+                                            colSpan={fieldInRow.colSpan?.toString()}
+                                            rowSpan={fieldInRow.rowSpan?.toString()}
                                         >
                                             {fieldInRow.name !== 'default' &&
                                                 fieldInRow.displayFormName}
@@ -166,8 +166,8 @@ export const PivotedCategoryComboTableBody = React.memo(
                                                 styles.noWrap,
                                             ]}
                                             key={fieldInRow.id}
-                                            colSpan={fieldInRow.colSpan}
-                                            rowSpan={fieldInRow.rowSpan}
+                                            colSpan={fieldInRow.colSpan?.toString()}
+                                            rowSpan={fieldInRow.rowSpan?.toString()}
                                         />
                                     )
                                 }
@@ -209,14 +209,12 @@ export const PivotedCategoryComboTableBody = React.memo(
                                         {i18n.t('Totals')}
                                     </TableCellHead>
                                 ) : (
-                                    <>
-                                        <RowTotal
-                                            dataElements={dataElements}
-                                            categoryOptionCombos={sortedCOCs}
-                                            row={index - 1}
-                                            pivot={true}
-                                        />
-                                    </>
+                                    <RowTotal
+                                        dataElements={dataElements}
+                                        categoryOptionCombos={sortedCOCs}
+                                        row={index - 1}
+                                        pivot={true}
+                                    />
                                 ))}
                         </TableRow>
                     )

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
@@ -13,6 +13,14 @@ import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.
 import styles from '../table-body.module.css'
 import { generateFormMatrix } from './generate-form-matrix/index.js'
 
+// move this and refactor to reuse from CategoryComboTableBody?
+const PaddingCell = () => (
+    <TableCell
+        className={styles.paddingCell}
+        dataTest="dhis2-dataentry-paddingcell"
+    ></TableCell>
+)
+
 /**
  * This component is based on the CategoryComboTableBody, and the two should be consolidate eventually.
  * Some of the reasons for the separate component:
@@ -33,7 +41,7 @@ export const PivotedCategoryComboTableBody = React.memo(
         globalFilterText,
         renderRowTotals,
         renderColumnTotals,
-        // maxColumnsInSection,
+        maxColumnsInSection,
         /*
         ,
         ,
@@ -53,12 +61,10 @@ export const PivotedCategoryComboTableBody = React.memo(
             categoryCombo.id
         )
 
-        // tbd
-        // const paddingCells = new Array(sortedCOCs.length).fill(0)
-        const paddingCells = new Array(categories.length - 1).fill(0)
-        // maxColumnsInSection > 0
-        //     ? new Array(maxColumnsInSection - sortedCOCs.length).fill(0)
-        //     : []
+        const paddingCells =
+            maxColumnsInSection > 0
+                ? new Array(maxColumnsInSection - dataElements.length).fill(0)
+                : []
 
         const categoryOptionsDetails = categories
             .map((c) => {
@@ -193,6 +199,11 @@ export const PivotedCategoryComboTableBody = React.memo(
                                 // should never get here
                                 return <>unsupported field</>
                             })}
+                            {paddingCells.map((_, i) => (
+                                <PaddingCell
+                                    key={`total_replacement_padding_row_${i}`}
+                                />
+                            ))}
                             {renderRowTotals && (
                                 <>
                                     <RowTotal
@@ -201,7 +212,6 @@ export const PivotedCategoryComboTableBody = React.memo(
                                         row={index - 1}
                                         pivot={true}
                                     />
-                                    {/* maybe a padding cell? */}
                                 </>
                             )}
                         </TableRow>
@@ -210,6 +220,7 @@ export const PivotedCategoryComboTableBody = React.memo(
                 {renderColumnTotals && (
                     <ColumnTotals
                         paddingCells={paddingCells}
+                        initialColumns={categories.length}
                         renderTotalSum={renderRowTotals && renderColumnTotals}
                         dataElements={dataElements}
                         categoryOptionCombos={sortedCOCs}

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
@@ -3,6 +3,10 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useMetadata, selectors } from '../../shared/index.js'
+import {
+    RowTotal,
+    ColumnTotals,
+} from '../category-combo-table-body/total-cells.jsx'
 import { DataEntryCell, DataEntryField } from '../data-entry-cell/index.js'
 import { getFieldId } from '../get-field-id.jsx'
 import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.jsx'
@@ -27,10 +31,13 @@ export const PivotedCategoryComboTableBody = React.memo(
         greyedFields,
         filterText,
         globalFilterText,
-        /*
-        maxColumnsInSection,
         renderRowTotals,
-        renderColumnTotals,*/
+        renderColumnTotals,
+        // maxColumnsInSection,
+        /*
+        ,
+        ,
+        ,*/
         displayOptions,
         collapsed,
     }) {
@@ -45,6 +52,13 @@ export const PivotedCategoryComboTableBody = React.memo(
             metadata,
             categoryCombo.id
         )
+
+        // tbd
+        // const paddingCells = new Array(sortedCOCs.length).fill(0)
+        const paddingCells = new Array(categories.length - 1).fill(0)
+        // maxColumnsInSection > 0
+        //     ? new Array(maxColumnsInSection - sortedCOCs.length).fill(0)
+        //     : []
 
         const categoryOptionsDetails = categories
             .map((c) => {
@@ -102,10 +116,10 @@ export const PivotedCategoryComboTableBody = React.memo(
 
         return (
             <>
-                {rowsMatrix.map((row, id /** todo: find suitable id */) => {
+                {rowsMatrix.map((row, index /** todo: find suitable id */) => {
                     return (
                         <TableRow
-                            key={id}
+                            key={index}
                             className={classNames({
                                 [styles.sectionRowCollapsed]: collapsed,
                             })}
@@ -179,9 +193,29 @@ export const PivotedCategoryComboTableBody = React.memo(
                                 // should never get here
                                 return <>unsupported field</>
                             })}
+                            {renderRowTotals && (
+                                <>
+                                    <RowTotal
+                                        dataElements={dataElements}
+                                        categoryOptionCombos={sortedCOCs}
+                                        row={index - 1}
+                                        pivot={true}
+                                    />
+                                    {/* maybe a padding cell? */}
+                                </>
+                            )}
                         </TableRow>
                     )
                 })}
+                {renderColumnTotals && (
+                    <ColumnTotals
+                        paddingCells={paddingCells}
+                        renderTotalSum={renderRowTotals && renderColumnTotals}
+                        dataElements={dataElements}
+                        categoryOptionCombos={sortedCOCs}
+                        pivot={true}
+                    />
+                )}
                 {hiddenItemsCount > 0 && (
                     <TableBodyHiddenByFiltersRow
                         hiddenItemsCount={hiddenItemsCount}
@@ -217,4 +251,6 @@ PivotedCategoryComboTableBody.propTypes = {
     /** Greyed fields is a Set where .has(fieldId) is true if that field is greyed/disabled */
     globalFilterText: PropTypes.string,
     greyedFields: PropTypes.instanceOf(Set),
+    renderColumnTotals: PropTypes.bool,
+    renderRowTotals: PropTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
@@ -1,7 +1,7 @@
 import i18n from '@dhis2/d2-i18n'
 import { TableRow, TableCell, TableCellHead } from '@dhis2/ui'
 import classNames from 'classnames'
-import PropTypes from 'prop-types'
+import propTypes from 'prop-types'
 import React from 'react'
 import { useMetadata, selectors } from '../../shared/index.js'
 import {
@@ -21,6 +21,49 @@ const PaddingCell = () => (
         dataTest="dhis2-dataentry-paddingcell"
     ></TableCell>
 )
+
+const TotalRow = ({
+    dataElements,
+    categoryOptionCombos,
+    index,
+    pivotMode,
+    pivotedCategory,
+    categories,
+}) => {
+    const indexAdjustment = pivotMode === 'move_categories' ? 2 : 1
+    if (index === 0) {
+        return (
+            <TableCellHead
+                className={styles.totalHeader}
+                rowSpan={indexAdjustment}
+            >
+                {i18n.t('Totals')}
+            </TableCellHead>
+        )
+    }
+    if (index === 1 && pivotMode === 'move_categories') {
+        return null
+    }
+    return (
+        <RowTotal
+            dataElements={dataElements}
+            categoryOptionCombos={categoryOptionCombos}
+            row={index - indexAdjustment}
+            pivotType={pivotMode}
+            pivotedCategory={pivotedCategory}
+            categories={categories}
+        />
+    )
+}
+
+TotalRow.propTypes = {
+    categories: propTypes.array,
+    categoryOptionCombos: propTypes.array,
+    dataElements: propTypes.array,
+    index: propTypes.number,
+    pivotMode: propTypes.oneOf(['move_categories', 'pivot', 'none']),
+    pivotedCategory: propTypes.string,
+}
 
 /**
  * This component is based on the CategoryComboTableBody, and the two should be consolidate eventually.
@@ -201,21 +244,18 @@ export const PivotedCategoryComboTableBody = React.memo(
                                     key={`total_replacement_padding_row_${i}`}
                                 />
                             ))}
-                            {renderRowTotals &&
-                                (index === 0 ? (
-                                    <TableCellHead
-                                        className={styles.totalHeader}
-                                    >
-                                        {i18n.t('Totals')}
-                                    </TableCellHead>
-                                ) : (
-                                    <RowTotal
-                                        dataElements={dataElements}
-                                        categoryOptionCombos={sortedCOCs}
-                                        row={index - 1}
-                                        pivot={true}
-                                    />
-                                ))}
+                            {renderRowTotals && (
+                                <TotalRow
+                                    dataElements={dataElements}
+                                    categoryOptionCombos={sortedCOCs}
+                                    index={index}
+                                    pivotMode={displayOptions.pivotMode}
+                                    pivotedCategory={
+                                        displayOptions?.pivotedCategory
+                                    }
+                                    categories={categories}
+                                />
+                            )}
                         </TableRow>
                     )
                 })}
@@ -226,7 +266,9 @@ export const PivotedCategoryComboTableBody = React.memo(
                         renderTotalSum={renderRowTotals && renderColumnTotals}
                         dataElements={dataElements}
                         categoryOptionCombos={sortedCOCs}
-                        pivot={true}
+                        pivotType={displayOptions.pivotMode}
+                        pivotedCategory={displayOptions.pivotedCategory}
+                        categories={categories}
                     />
                 )}
                 {hiddenItemsCount > 0 && (
@@ -240,31 +282,31 @@ export const PivotedCategoryComboTableBody = React.memo(
 )
 
 PivotedCategoryComboTableBody.propTypes = {
-    categoryCombo: PropTypes.shape({
-        id: PropTypes.string.isRequired,
+    categoryCombo: propTypes.shape({
+        id: propTypes.string.isRequired,
     }),
-    collapsed: PropTypes.bool,
-    dataElements: PropTypes.arrayOf(
-        PropTypes.shape({
-            id: PropTypes.string.isRequired,
-            displayFormName: PropTypes.string,
-            headerCombo: PropTypes.shape({
-                id: PropTypes.string,
+    collapsed: propTypes.bool,
+    dataElements: propTypes.arrayOf(
+        propTypes.shape({
+            id: propTypes.string.isRequired,
+            displayFormName: propTypes.string,
+            headerCombo: propTypes.shape({
+                id: propTypes.string,
             }),
-            valueType: PropTypes.string,
+            valueType: propTypes.string,
         })
     ),
-    displayOptions: PropTypes.shape({
-        afterSectionText: PropTypes.string,
-        beforeSectionText: PropTypes.string,
-        pivotMode: PropTypes.oneOf(['move_categories', 'pivot']),
-        pivotedCategory: PropTypes.string,
+    displayOptions: propTypes.shape({
+        afterSectionText: propTypes.string,
+        beforeSectionText: propTypes.string,
+        pivotMode: propTypes.oneOf(['move_categories', 'pivot']),
+        pivotedCategory: propTypes.string,
     }),
-    filterText: PropTypes.string,
+    filterText: propTypes.string,
     /** Greyed fields is a Set where .has(fieldId) is true if that field is greyed/disabled */
-    globalFilterText: PropTypes.string,
-    greyedFields: PropTypes.instanceOf(Set),
-    maxColumnsInSection: PropTypes.number,
-    renderColumnTotals: PropTypes.bool,
-    renderRowTotals: PropTypes.bool,
+    globalFilterText: propTypes.string,
+    greyedFields: propTypes.instanceOf(Set),
+    maxColumnsInSection: propTypes.number,
+    renderColumnTotals: propTypes.bool,
+    renderRowTotals: propTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import { TableRow, TableCell, TableCellHead } from '@dhis2/ui'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
@@ -42,10 +43,6 @@ export const PivotedCategoryComboTableBody = React.memo(
         renderRowTotals,
         renderColumnTotals,
         maxColumnsInSection,
-        /*
-        ,
-        ,
-        ,*/
         displayOptions,
         collapsed,
     }) {
@@ -204,16 +201,23 @@ export const PivotedCategoryComboTableBody = React.memo(
                                     key={`total_replacement_padding_row_${i}`}
                                 />
                             ))}
-                            {renderRowTotals && (
-                                <>
-                                    <RowTotal
-                                        dataElements={dataElements}
-                                        categoryOptionCombos={sortedCOCs}
-                                        row={index - 1}
-                                        pivot={true}
-                                    />
-                                </>
-                            )}
+                            {renderRowTotals &&
+                                (index === 0 ? (
+                                    <TableCellHead
+                                        className={styles.totalHeader}
+                                    >
+                                        {i18n.t('Totals')}
+                                    </TableCellHead>
+                                ) : (
+                                    <>
+                                        <RowTotal
+                                            dataElements={dataElements}
+                                            categoryOptionCombos={sortedCOCs}
+                                            row={index - 1}
+                                            pivot={true}
+                                        />
+                                    </>
+                                ))}
                         </TableRow>
                     )
                 })}
@@ -262,6 +266,7 @@ PivotedCategoryComboTableBody.propTypes = {
     /** Greyed fields is a Set where .has(fieldId) is true if that field is greyed/disabled */
     globalFilterText: PropTypes.string,
     greyedFields: PropTypes.instanceOf(Set),
+    maxColumnsInSection: PropTypes.number,
     renderColumnTotals: PropTypes.bool,
     renderRowTotals: PropTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import propTypes from 'prop-types'
 import React from 'react'
 import { useMetadata, selectors } from '../../shared/index.js'
+import PaddingCell from '../category-combo-table-body/padding-cell.jsx'
 import {
     RowTotal,
     ColumnTotals,
@@ -13,14 +14,6 @@ import { getFieldId } from '../get-field-id.jsx'
 import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.jsx'
 import styles from '../table-body.module.css'
 import { generateFormMatrix } from './generate-form-matrix/index.js'
-
-// move this and refactor to reuse from CategoryComboTableBody?
-const PaddingCell = () => (
-    <TableCell
-        className={styles.paddingCell}
-        dataTest="dhis2-dataentry-paddingcell"
-    ></TableCell>
-)
 
 const TotalRow = ({
     dataElements,

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.test.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.test.jsx
@@ -1,0 +1,766 @@
+import { Table } from '@dhis2/ui'
+import { getByText } from '@testing-library/react'
+import React from 'react'
+import { useMetadata } from '../../shared/metadata/use-metadata.js'
+import { useDataSetId } from '../../shared/use-context-selection/use-context-selection.js'
+import { render } from '../../test-utils/index.js'
+import { PivotedCategoryComboTableBody } from './category-combo-table-body-pivoted.jsx'
+
+jest.mock(
+    '../../shared/use-context-selection/use-context-selection.js',
+    () => ({
+        ...jest.requireActual(
+            '../../shared/use-context-selection/use-context-selection.js'
+        ),
+        useDataSetId: jest.fn(),
+    })
+)
+
+jest.mock('../../shared/metadata/use-metadata.js', () => ({
+    useMetadata: jest.fn(),
+}))
+
+const MOCK_VALUES = {
+    FTRrcoaog83: {
+        HllvX50cXC0: {
+            value: '5',
+        },
+    },
+    FTRrcoaog83_NUMERIC: {
+        HllvX50cXC0: {
+            value: '150',
+        },
+    },
+}
+
+jest.mock('../../shared/stores/data-value-store.js', () => ({
+    useValueStore: jest.fn().mockImplementation((func) => {
+        const state = {
+            getInitialDataValue: ({ dataElementId, categoryOptionComboId }) => {
+                return MOCK_VALUES?.[dataElementId]?.[categoryOptionComboId]
+                    ?.value
+            },
+            hasComment: () => false,
+            getMinMaxValues: () => [],
+            getDataValue: () => '',
+            getDataValues: () => {
+                return MOCK_VALUES
+            },
+        }
+
+        return func(state)
+    }),
+}))
+
+const categories = {
+    fMZEcRHuamy: {
+        allItems: false,
+        categoryOptions: ['qkPbeWaFsnU', 'wbrDrL2aYEc'],
+        code: 'LOC_FIX_OUTREACH',
+        created: '2011-12-24T12:24:25.155',
+        dataDimension: true,
+        dataDimensionType: 'DISAGGREGATION',
+        dimension: 'fMZEcRHuamy',
+        dimensionType: 'CATEGORY',
+        displayFormName: 'Location Fixed/Outreach',
+        displayName: 'Location Fixed/Outreach',
+        displayShortName: 'Location Fixed/Outreach',
+        favorite: false,
+        id: 'fMZEcRHuamy',
+        lastUpdated: '2013-05-28T09:59:32.881',
+        name: 'Location Fixed/Outreach',
+        shortName: 'Location Fixed/Outreach',
+    },
+    YNZyaJHiHYq: {
+        allItems: false,
+        categoryOptions: ['btOyqprQ9e8', 'GEqzEKCHoGA'],
+        code: 'EPI_NUTR_AGE',
+        created: '2011-12-24T12:24:25.155',
+        dataDimension: true,
+        dataDimensionType: 'DISAGGREGATION',
+        dimension: 'YNZyaJHiHYq',
+        dimensionType: 'CATEGORY',
+        displayFormName: 'EPI/nutrition age',
+        displayName: 'EPI/nutrition age',
+        displayShortName: 'EPI/nutrition age',
+        favorite: false,
+        id: 'YNZyaJHiHYq',
+        lastUpdated: '2013-05-28T09:32:43.922',
+        name: 'EPI/nutrition age',
+        shortName: 'EPI/nutrition age',
+    },
+    GLevLNI9wkl: {
+        allItems: false,
+        categoryOptions: ['xYerKDKCefk'],
+        code: 'default',
+        created: '2012-11-21T12:15:18.537',
+        dataDimension: false,
+        dataDimensionType: 'DISAGGREGATION',
+        dimension: 'GLevLNI9wkl',
+        dimensionType: 'CATEGORY',
+        displayFormName: 'default',
+        displayName: 'default',
+        displayShortName: 'default',
+        favorite: false,
+        id: 'GLevLNI9wkl',
+        lastUpdated: '2023-05-15T23:04:45.545',
+        name: 'default',
+    },
+}
+
+const categoryOptions = {
+    xYerKDKCefk: {
+        code: 'default',
+        created: '2011-12-24T12:24:24.149',
+        dimensionItem: 'xYerKDKCefk',
+        dimensionItemType: 'CATEGORY_OPTION',
+        displayFormName: 'default',
+        displayName: 'default',
+        displayShortName: 'default',
+        favorite: false,
+        id: 'xYerKDKCefk',
+        isDefault: true,
+        lastUpdated: '2016-04-12T20:37:48.414',
+        name: 'default',
+        organisationUnits: [],
+    },
+    qkPbeWaFsnU: {
+        code: 'FIXED',
+        created: '2011-12-24T12:24:24.149',
+        dimensionItem: 'qkPbeWaFsnU',
+        dimensionItemType: 'CATEGORY_OPTION',
+        displayFormName: 'Fixed',
+        displayName: 'Fixed',
+        displayShortName: 'Fixed',
+        favorite: false,
+        id: 'qkPbeWaFsnU',
+        isDefault: false,
+        lastUpdated: '2011-12-24T12:24:24.149',
+        name: 'Fixed',
+        organisationUnits: [],
+        shortName: 'Fixed',
+    },
+    wbrDrL2aYEc: {
+        code: 'OUTREACH\nOUTREACH',
+        created: '2011-12-24T12:24:24.149',
+        dimensionItem: 'wbrDrL2aYEc',
+        dimensionItemType: 'CATEGORY_OPTION',
+        displayFormName: 'Outreach',
+        displayName: 'Outreach',
+        displayShortName: 'Outreach',
+        favorite: false,
+        id: 'wbrDrL2aYEc',
+        isDefault: false,
+        lastUpdated: '2011-12-24T12:24:24.149',
+        name: 'Outreach',
+        organisationUnits: [],
+        shortName: 'Outreach',
+    },
+    btOyqprQ9e8: {
+        code: '<1y',
+        created: '2011-12-24T12:24:24.149',
+        dimensionItem: 'btOyqprQ9e8',
+        dimensionItemType: 'CATEGORY_OPTION',
+        displayFormName: '<1y',
+        displayName: '<1y',
+        displayShortName: '<1y',
+        favorite: false,
+        id: 'btOyqprQ9e8',
+        isDefault: false,
+        lastUpdated: '2015-03-11T11:56:54.123',
+        name: '<1y',
+        organisationUnits: [],
+        shortName: '<1y',
+    },
+    GEqzEKCHoGA: {
+        code: '>1y',
+        created: '2011-12-24T12:24:24.149',
+        dimensionItem: 'GEqzEKCHoGA',
+        dimensionItemType: 'CATEGORY_OPTION',
+        displayFormName: '>1y',
+        displayName: '>1y',
+        displayShortName: '>1y',
+        favorite: false,
+        id: 'GEqzEKCHoGA',
+        isDefault: false,
+        lastUpdated: '2014-03-05T04:57:24.116',
+        name: '>1y',
+        organisationUnits: [],
+        shortName: '>1y',
+    },
+}
+
+const dataElements = {
+    s46m5MS0hxu: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_359706',
+        created: '2010-02-05T10:58:19.053',
+        description: 'BCG doses administered.',
+        displayFormName: 'BCG doses given',
+        displayName: 'BCG doses given',
+        displayShortName: 'BCG doses given',
+        id: 's46m5MS0hxu',
+        lastUpdated: '2015-04-02T19:51:21.183',
+        name: 'BCG doses given',
+        valueType: 'INTEGER',
+        zeroIsSignificant: false,
+    },
+    UOlfIjgN8X6: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_36',
+        created: '2012-11-05T12:48:48.279',
+        displayFormName: 'Fully Immunized child',
+        displayName: 'Fully Immunized child',
+        displayShortName: 'Fully Immunized Child',
+        id: 'UOlfIjgN8X6',
+        lastUpdated: '2015-02-24T16:03:07.926',
+        name: 'Fully Immunized child',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    z7duEFcpApd: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_359709',
+        created: '2010-02-05T10:57:58.041',
+        displayFormName: 'LLITN given at Penta3',
+        displayName: 'LLITN given at Penta3',
+        displayShortName: 'LLITN at Penta3',
+        id: 'z7duEFcpApd',
+        lastUpdated: '2014-11-11T21:56:05.884',
+        name: 'LLITN given at Penta3',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    x3Do5e7g4Qo: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_359707',
+        created: '2010-02-05T10:57:23.270',
+        description: '0-13 days after birth.',
+        displayFormName: 'OPV0 doses given',
+        displayName: 'OPV0 doses given',
+        displayShortName: 'OPV0 doses given ',
+        id: 'x3Do5e7g4Qo',
+        lastUpdated: '2014-11-11T21:56:05.530',
+        name: 'OPV0 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    pikOziyCXbM: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_19',
+        created: '2012-11-05T12:55:05.154',
+        displayFormName: 'OPV1 doses given',
+        displayName: 'OPV1 doses given',
+        displayShortName: 'OPV1 doses given',
+        id: 'pikOziyCXbM',
+        lastUpdated: '2014-11-11T21:56:05.529',
+        name: 'OPV1 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    O05mAByOgAv: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_20',
+        created: '2012-11-05T12:47:11.853',
+        displayFormName: 'OPV2 doses given',
+        displayName: 'OPV2 doses given',
+        displayShortName: 'OPV2 doses given',
+        id: 'O05mAByOgAv',
+        lastUpdated: '2014-11-11T21:56:05.833',
+        name: 'OPV2 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    vI2csg55S9C: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_21',
+        created: '2012-11-05T12:47:33.202',
+        displayFormName: 'OPV3 doses given',
+        displayName: 'OPV3 doses given',
+        displayShortName: 'OPV3 doses given',
+        id: 'vI2csg55S9C',
+        lastUpdated: '2014-11-11T21:56:05.531',
+        name: 'OPV3 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    xc8gmAKfO95: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_359722',
+        created: '2010-02-05T10:57:21.613',
+        description: 'Pneumococcal Vaccine',
+        displayFormName: 'PCV1 doses given',
+        displayName: 'PCV1 doses given',
+        displayShortName: 'PCV1 doses given',
+        id: 'xc8gmAKfO95',
+        lastUpdated: '2014-11-11T21:56:05.913',
+        name: 'PCV1 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    mGN1az8Xub6: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_359723',
+        created: '2010-02-05T10:57:21.488',
+        description: 'Penumococcal Vaccine',
+        displayFormName: 'PCV2 doses given',
+        displayName: 'PCV2 doses given',
+        displayShortName: 'PCV2 doses given',
+        id: 'mGN1az8Xub6',
+        lastUpdated: '2014-11-11T21:56:05.920',
+        name: 'PCV2 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    L2kxa2IA2cs: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_359724',
+        created: '2010-02-05T10:57:21.363',
+        description: 'Penumococcal Vaccine',
+        displayFormName: 'PCV3 doses given',
+        displayName: 'PCV3 doses given',
+        displayShortName: 'PCV3 doses given',
+        id: 'L2kxa2IA2cs',
+        lastUpdated: '2014-11-11T21:56:05.713',
+        name: 'PCV3 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    fClA2Erf6IO: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_23',
+        created: '2012-11-05T12:47:53.340',
+        displayFormName: 'Penta1 doses given',
+        displayName: 'Penta1 doses given',
+        displayShortName: 'Penta1 doses given',
+        id: 'fClA2Erf6IO',
+        lastUpdated: '2014-11-11T21:56:05.879',
+        name: 'Penta1 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    I78gJm4KBo7: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_24',
+        created: '2012-11-05T12:48:08.439',
+        displayFormName: 'Penta2 doses given',
+        displayName: 'Penta2 doses given',
+        displayShortName: 'Penta2 doses given',
+        id: 'I78gJm4KBo7',
+        lastUpdated: '2014-11-11T21:56:05.822',
+        name: 'Penta2 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    n6aMJNLdvep: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_25',
+        created: '2012-11-05T12:56:39.621',
+        displayFormName: 'Penta3 doses given',
+        displayName: 'Penta3 doses given',
+        displayShortName: 'Penta3 doses given',
+        id: 'n6aMJNLdvep',
+        lastUpdated: '2014-11-11T21:56:05.768',
+        name: 'Penta3 doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    l6byfWFUGaP: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_35',
+        created: '2011-12-24T12:24:25.088',
+        displayFormName: 'Yellow Fever doses given',
+        displayName: 'Yellow Fever doses given',
+        displayShortName: 'Yellow Fever doses given',
+        id: 'l6byfWFUGaP',
+        lastUpdated: '2015-08-06T13:28:05.512',
+        name: 'Yellow Fever doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    YtbsuPPo010: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'dzjKKQq0cSO' },
+        code: 'DE_34',
+        created: '2012-11-05T12:48:30.861',
+        displayFormName: 'Measles doses given',
+        displayName: 'Measles doses given',
+        displayShortName: 'Measles doses given',
+        id: 'YtbsuPPo010',
+        lastUpdated: '2014-11-11T21:56:05.875',
+        name: 'Measles doses given',
+        valueType: 'NUMBER',
+        zeroIsSignificant: false,
+    },
+    FTRrcoaog83: {
+        aggregationType: 'SUM',
+        categoryCombo: { id: 'bjDvmb4bfuf' },
+        code: 'DE_1148614',
+        created: '2011-04-20T17:54:58.775',
+        displayFormName: 'Accute Flaccid Paralysis (Deaths < 5 yrs)',
+        displayName: 'Accute Flaccid Paralysis (Deaths < 5 yrs)',
+        displayShortName: 'Accute Flaccid Paral (Deaths < 5 yrs)',
+        id: 'FTRrcoaog83',
+        lastUpdated: '2017-05-19T15:13:52.488',
+        name: 'Accute Flaccid Paralysis (Deaths < 5 yrs)',
+        valueType: 'NUMBER',
+    },
+}
+
+const categoryCombos = {
+    dzjKKQq0cSO: {
+        id: 'dzjKKQq0cSO',
+        categories: ['fMZEcRHuamy', 'YNZyaJHiHYq'],
+        categoryOptionCombos: [
+            {
+                categoryOptions: ['wbrDrL2aYEc', 'btOyqprQ9e8'],
+                code: 'COC_290',
+                displayName: 'Outreach, <1y',
+                id: 'V6L425pT3A0',
+                name: 'Outreach, <1y',
+            },
+            {
+                categoryOptions: ['wbrDrL2aYEc', 'GEqzEKCHoGA'],
+                code: 'COC_289',
+                displayName: 'Outreach, >1y',
+                id: 'hEFKSsPV5et',
+                name: 'Outreach, >1y',
+            },
+            {
+                categoryOptions: ['qkPbeWaFsnU', 'btOyqprQ9e8'],
+                code: 'COC_292',
+                displayName: 'Fixed, <1y',
+                id: 'Prlt0C1RF0s',
+                name: 'Fixed, <1y',
+            },
+            {
+                categoryOptions: ['qkPbeWaFsnU', 'GEqzEKCHoGA'],
+                code: 'COC_291',
+                displayName: 'Fixed, >1y',
+                id: 'psbwp3CQEhs',
+                name: 'Fixed, >1y',
+            },
+        ],
+        created: '2011-12-24T12:24:25.203',
+        dataDimensionType: 'DISAGGREGATION',
+        displayName: 'Location and age group',
+        favorite: false,
+        isDefault: false,
+        lastUpdated: '2011-12-24T12:24:25.203',
+        name: 'Location and age group',
+    },
+    bjDvmb4bfuf: {
+        categories: ['GLevLNI9wkl'],
+        categoryOptionCombos: [
+            {
+                code: 'default',
+                name: 'default',
+                categoryOptions: ['xYerKDKCefk'],
+                displayName: 'default',
+                id: 'HllvX50cXC0',
+            },
+        ],
+        code: 'default',
+        created: '2011-12-24T12:24:25.203',
+        dataDimensionType: 'DISAGGREGATION',
+        displayName: 'default',
+        favorite: false,
+        id: 'bjDvmb4bfuf',
+        isDefault: true,
+        lastUpdated: '2016-04-12T20:37:49.126',
+        name: 'default',
+    },
+}
+
+const metadata = {
+    categories,
+    categoryOptions,
+    categoryCombos,
+    dataElements,
+}
+
+const PIVOT_DISPLAY_OPTIONS = { pivotMode: 'pivot' }
+
+describe('<PivotedCategoryComboTableBody />', () => {
+    useMetadata.mockReturnValue({ data: metadata })
+    useDataSetId.mockReturnValue(['dataSet1'])
+
+    it('should render rows and columns based on the data elements and categorycombo', () => {
+        const tableDataElements = [
+            dataElements.s46m5MS0hxu,
+            dataElements.UOlfIjgN8X6,
+            dataElements.z7duEFcpApd,
+            dataElements.x3Do5e7g4Qo,
+            dataElements.pikOziyCXbM,
+            dataElements.O05mAByOgAv,
+            dataElements.vI2csg55S9C,
+            dataElements.xc8gmAKfO95,
+            dataElements.mGN1az8Xub6,
+            dataElements.L2kxa2IA2cs,
+            dataElements.fClA2Erf6IO,
+            dataElements.I78gJm4KBo7,
+            dataElements.n6aMJNLdvep,
+            dataElements.l6byfWFUGaP,
+            dataElements.YtbsuPPo010,
+        ]
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    categoryCombo={categoryCombos.dzjKKQq0cSO}
+                    dataElements={tableDataElements}
+                    filterText=""
+                    globalFilterText=""
+                    displayOptions={PIVOT_DISPLAY_OPTIONS}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const inputCells = result.getAllByTestId(
+            'dhis2-dataentryapp-dataentrycell'
+        )
+        expect(inputCells.length).toBe(tableDataElements.length * 4)
+
+        tableDataElements.forEach((dataElement) => {
+            expect(
+                getByText(result.container, dataElement.displayName)
+            ).toBeTruthy()
+        })
+    })
+
+    it('should filter the columns by displayFormName (filterText) when pivotMode is move_categories', () => {
+        // filterText only filters data elements when pivotMode is
+        // 'move_categories' - in 'pivot' mode it filters COCs instead
+        // (a different axis than the original, non-pivoted test covered).
+        const tableDataElements = [
+            dataElements.s46m5MS0hxu,
+            dataElements.UOlfIjgN8X6,
+            dataElements.z7duEFcpApd,
+            dataElements.x3Do5e7g4Qo,
+            dataElements.pikOziyCXbM,
+            dataElements.O05mAByOgAv,
+            dataElements.vI2csg55S9C,
+            dataElements.xc8gmAKfO95,
+            dataElements.mGN1az8Xub6,
+            dataElements.L2kxa2IA2cs,
+            dataElements.fClA2Erf6IO,
+            dataElements.I78gJm4KBo7,
+            dataElements.n6aMJNLdvep,
+            dataElements.l6byfWFUGaP,
+            dataElements.YtbsuPPo010,
+        ]
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    categoryCombo={categoryCombos.dzjKKQq0cSO}
+                    dataElements={tableDataElements}
+                    filterText="doses given"
+                    globalFilterText=""
+                    displayOptions={{
+                        pivotMode: 'move_categories',
+                        pivotedCategory: 'fMZEcRHuamy',
+                    }}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        // 13 of the 15 data elements' displayFormName include "doses given"
+        // ("Fully Immunized child" and "LLITN given at Penta3" don't)
+        expect(
+            getByText(result.container, '2 items hidden by filter')
+        ).toBeTruthy()
+    })
+
+    it('should filter the columns by displayFormName (globalFilterText)', () => {
+        const tableDataElements = [
+            dataElements.s46m5MS0hxu,
+            dataElements.UOlfIjgN8X6,
+            dataElements.z7duEFcpApd,
+            dataElements.x3Do5e7g4Qo,
+            dataElements.pikOziyCXbM,
+            dataElements.O05mAByOgAv,
+            dataElements.vI2csg55S9C,
+            dataElements.xc8gmAKfO95,
+            dataElements.mGN1az8Xub6,
+            dataElements.L2kxa2IA2cs,
+            dataElements.fClA2Erf6IO,
+            dataElements.I78gJm4KBo7,
+            dataElements.n6aMJNLdvep,
+            dataElements.l6byfWFUGaP,
+            dataElements.YtbsuPPo010,
+        ]
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    categoryCombo={categoryCombos.dzjKKQq0cSO}
+                    dataElements={tableDataElements}
+                    filterText=""
+                    globalFilterText="doses given"
+                    displayOptions={PIVOT_DISPLAY_OPTIONS}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        // Unlike the local `filterText`, `globalFilterText` filters data
+        // elements regardless of pivotMode, so the resulting grid should
+        // only contain data-entry cells for the 13 matching data elements.
+        const inputCells = result.getAllByTestId(
+            'dhis2-dataentryapp-dataentrycell'
+        )
+        expect(inputCells.length).toBe(13 * 4)
+    })
+
+    it('should disable fields in greyedFields set', () => {
+        const tableDataElements = [
+            dataElements.s46m5MS0hxu,
+            dataElements.UOlfIjgN8X6,
+            dataElements.z7duEFcpApd,
+            dataElements.x3Do5e7g4Qo,
+            dataElements.pikOziyCXbM,
+            dataElements.O05mAByOgAv,
+            dataElements.vI2csg55S9C,
+            dataElements.xc8gmAKfO95,
+            dataElements.mGN1az8Xub6,
+            dataElements.L2kxa2IA2cs,
+            dataElements.fClA2Erf6IO,
+            dataElements.I78gJm4KBo7,
+            dataElements.n6aMJNLdvep,
+            dataElements.l6byfWFUGaP,
+            dataElements.YtbsuPPo010,
+        ]
+
+        const greyedFields = new Set()
+        greyedFields.add('s46m5MS0hxu.Prlt0C1RF0s')
+        greyedFields.add('s46m5MS0hxu.psbwp3CQEhs')
+        greyedFields.add('s46m5MS0hxu.V6L425pT3A0')
+        greyedFields.add('s46m5MS0hxu.hEFKSsPV5et')
+        greyedFields.add('UOlfIjgN8X6.Prlt0C1RF0s')
+        greyedFields.add('UOlfIjgN8X6.psbwp3CQEhs')
+        greyedFields.add('UOlfIjgN8X6.V6L425pT3A0')
+        greyedFields.add('UOlfIjgN8X6.hEFKSsPV5et')
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    categoryCombo={categoryCombos.dzjKKQq0cSO}
+                    dataElements={tableDataElements}
+                    greyedFields={greyedFields}
+                    filterText=""
+                    globalFilterText=""
+                    displayOptions={PIVOT_DISPLAY_OPTIONS}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const disabledInputs =
+            result.container.getElementsByClassName('disabled')
+
+        expect(disabledInputs.length).toBe(8)
+    })
+
+    it('should add padding cells when needed', () => {
+        const tableDataElements = [dataElements.FTRrcoaog83]
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    categoryCombo={categoryCombos.bjDvmb4bfuf}
+                    dataElements={tableDataElements}
+                    maxColumnsInSection={4}
+                    filterText=""
+                    globalFilterText=""
+                    displayOptions={PIVOT_DISPLAY_OPTIONS}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const paddingCells = result.getAllByTestId(
+            'dhis2-dataentry-paddingcell'
+        )
+        expect(paddingCells.length).toBe(6)
+    })
+
+    it('should render the column totals when renderColumTotals = true', () => {
+        const tableDataElements = [dataElements.FTRrcoaog83]
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    renderColumnTotals
+                    categoryCombo={categoryCombos.bjDvmb4bfuf}
+                    dataElements={tableDataElements}
+                    filterText=""
+                    globalFilterText=""
+                    displayOptions={PIVOT_DISPLAY_OPTIONS}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const columnTotalsRow = result.getByTestId(
+            'dhis2-dataentry-columntotals'
+        )
+        expect(columnTotalsRow).toBeTruthy()
+
+        const totalCells = result.getAllByText('5', {
+            selector: '[data-test="dhis2-dataentry-totalcell"]',
+        })
+        expect(totalCells.length).toBe(1)
+    })
+
+    it('should render the row totals when renderTowTotals = true', () => {
+        const tableDataElements = [dataElements.FTRrcoaog83]
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    renderRowTotals
+                    categoryCombo={categoryCombos.bjDvmb4bfuf}
+                    dataElements={tableDataElements}
+                    filterText=""
+                    globalFilterText=""
+                    displayOptions={PIVOT_DISPLAY_OPTIONS}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        const totalCells = result.getAllByTestId('dhis2-dataentry-totalcell')
+        expect(totalCells.length).toBe(1)
+        expect(getByText(result.container, '5')).toBeTruthy()
+    })
+})

--- a/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.test.jsx
+++ b/src/data-workspace/category-combo-table-body-pivoted/category-combo-table-body-pivoted.test.jsx
@@ -31,6 +31,19 @@ const MOCK_VALUES = {
             value: '150',
         },
     },
+    s46m5MS0hxu: {
+        Prlt0C1RF0s: {
+            value: '10',
+        },
+        psbwp3CQEhs: {
+            value: '20',
+        },
+    },
+    UOlfIjgN8X6: {
+        V6L425pT3A0: {
+            value: '30',
+        },
+    },
 }
 
 jest.mock('../../shared/stores/data-value-store.js', () => ({
@@ -762,5 +775,55 @@ describe('<PivotedCategoryComboTableBody />', () => {
         const totalCells = result.getAllByTestId('dhis2-dataentry-totalcell')
         expect(totalCells.length).toBe(1)
         expect(getByText(result.container, '5')).toBeTruthy()
+    })
+
+    it('should render both row and column totals when displayOptions has a pivotedCategory', () => {
+        // With pivotMode: 'move_categories', rows are grouped by
+        // dataElement x pivotedCategory-option (here: Location), and the
+        // remaining category (age) becomes the columns. Row/column totals
+        // still need to line up correctly with that grouping rather than
+        // with the plain dataElement x coc matrix.
+        const tableDataElements = [
+            dataElements.s46m5MS0hxu,
+            dataElements.UOlfIjgN8X6,
+        ]
+
+        const result = render(
+            <Table>
+                <PivotedCategoryComboTableBody
+                    renderColumnTotals
+                    renderRowTotals
+                    categoryCombo={categoryCombos.dzjKKQq0cSO}
+                    dataElements={tableDataElements}
+                    filterText=""
+                    globalFilterText=""
+                    displayOptions={{
+                        pivotMode: 'move_categories',
+                        pivotedCategory: 'fMZEcRHuamy',
+                    }}
+                />
+            </Table>,
+            {
+                wrapper: ({ children }) => <>{children}</>,
+            }
+        )
+
+        // One row per (dataElement, location-option) pair: BCG/Fixed,
+        // BCG/Outreach, Fully Immunized/Fixed, Fully Immunized/Outreach.
+        // Values (from MOCK_VALUES) are: BCG/Fixed/<1y=10, BCG/Fixed/>1y=20,
+        // Fully Immunized/Outreach/<1y=30, all others unset (0).
+        const rowTotals = result
+            .getAllByTestId('dhis2-dataentry-totalcell')
+            .map((cell) => cell.textContent)
+        expect(rowTotals).toEqual(['30', '0', '0', '30', '40', '20', '60'])
+
+        const columnTotalsRow = result.getByTestId(
+            'dhis2-dataentry-columntotals'
+        )
+        expect(columnTotalsRow).toBeTruthy()
+
+        // Both a row-totals header ("Totals" spanning the two header rows)
+        // and a column-totals header are rendered.
+        expect(result.getAllByText('Totals').length).toBe(2)
     })
 })

--- a/src/data-workspace/category-combo-table-body/calculate-totals.js
+++ b/src/data-workspace/category-combo-table-body/calculate-totals.js
@@ -9,4 +9,5 @@ const calculateColumnTotal = (matrix, column = 0) =>
 export const calculateColumnTotals = (matrix) =>
     matrix[0]?.map((_, i) => calculateColumnTotal(matrix, i)) || []
 
-export const calculateRowTotal = (matrix, row = 0) => matrix[row].reduce(sum, 0)
+export const calculateRowTotal = (matrix, row = 0) =>
+    matrix?.[row]?.reduce(sum, 0)

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body-header.jsx
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body-header.jsx
@@ -114,7 +114,9 @@ export const CategoryComboTableBodyHeader = ({
                         {hideRowTotalsDueToNonNumberValueTypes ? (
                             <PaddingCell key={'total_header_padding'} />
                         ) : (
-                            <TotalHeader rowSpan={categories.length} />
+                            <TotalHeader
+                                rowSpan={categories.length.toString()}
+                            />
                         )}
                     </>
                 )}

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.jsx
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.jsx
@@ -9,6 +9,7 @@ import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.
 import styles from '../table-body.module.css'
 import { CategoryComboTableBodyHeader } from './category-combo-table-body-header.jsx'
 import { DataElementCell } from './data-element-cell.jsx'
+import PaddingCell from './padding-cell.jsx'
 import { ColumnTotals, RowTotal } from './total-cells.jsx'
 
 export const CategoryComboTableBody = React.memo(
@@ -180,10 +181,3 @@ CategoryComboTableBody.propTypes = {
     renderColumnTotals: PropTypes.bool,
     renderRowTotals: PropTypes.bool,
 }
-
-const PaddingCell = () => (
-    <TableCell
-        className={styles.paddingCell}
-        dataTest="dhis2-dataentry-paddingcell"
-    ></TableCell>
-)

--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.jsx
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.jsx
@@ -1,4 +1,4 @@
-import { TableBody, TableCell, TableRow } from '@dhis2/ui'
+import { TableBody, TableRow } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useCallback, useMemo } from 'react'

--- a/src/data-workspace/category-combo-table-body/total-cells.jsx
+++ b/src/data-workspace/category-combo-table-body/total-cells.jsx
@@ -51,6 +51,14 @@ export const RowTotal = ({
     row,
     pivot = false,
 }) => {
+    // maybe move this?
+    if (pivot && row === -1) {
+        return (
+            <TableCellHead className={styles.totalHeader}>
+                {i18n.t('Totals')}
+            </TableCellHead>
+        )
+    }
     const matrix = useValueMatrix(dataElements, categoryOptionCombos, pivot)
     const rowTotal = useMemo(
         () => calculateRowTotal(matrix, row),
@@ -68,6 +76,7 @@ RowTotal.propTypes = {
 
 export const ColumnTotals = ({
     renderTotalSum,
+    initialColumns = 1,
     paddingCells,
     dataElements,
     categoryOptionCombos,
@@ -78,19 +87,19 @@ export const ColumnTotals = ({
 
     return (
         <TableRow dataTest="dhis2-dataentry-columntotals">
-            <TableCellHead className={styles.totalHeader}>
+            <TableCellHead
+                className={styles.totalHeader}
+                colSpan={initialColumns}
+            >
                 {i18n.t('Totals')}
             </TableCellHead>
-            {pivot &&
-                paddingCells.map((_, i) =>
-                    i === 0 ? (
-                        <PaddingCell colSpan={paddingCells.length} key={i} />
-                    ) : null
-                )}
+
             {columnTotals.map((v, i) => (
                 <TotalCell key={i}>{v}</TotalCell>
             ))}
-            {!pivot && paddingCells.map((_, i) => <TotalCell key={i} />)}
+            {paddingCells.map((_, i) => (
+                <TotalCell key={i} />
+            ))}
             {renderTotalSum && (
                 <TotalCell>
                     {columnTotals.reduce((acc, curr) => acc + curr, 0)}

--- a/src/data-workspace/category-combo-table-body/total-cells.jsx
+++ b/src/data-workspace/category-combo-table-body/total-cells.jsx
@@ -7,6 +7,21 @@ import styles from '../table-body.module.css'
 import { calculateColumnTotals, calculateRowTotal } from './calculate-totals.js'
 import { useValueMatrix } from './use-value-matrix.js'
 
+export const PaddingCell = ({ children, colSpan }) => (
+    <TableCell
+        className={cx('total-cell', styles.totalCell)}
+        dataTest="dhis2-dataentry-totalcell-padding"
+        colSpan={colSpan}
+    >
+        {children}
+    </TableCell>
+)
+
+PaddingCell.propTypes = {
+    children: propTypes.node,
+    colSpan: propTypes.number,
+}
+
 export const TotalCell = ({ children }) => (
     <TableCell
         className={cx('total-cell', styles.totalCell)}
@@ -30,8 +45,13 @@ TotalHeader.propTypes = {
     rowSpan: propTypes.number,
 }
 
-export const RowTotal = ({ dataElements, categoryOptionCombos, row }) => {
-    const matrix = useValueMatrix(dataElements, categoryOptionCombos)
+export const RowTotal = ({
+    dataElements,
+    categoryOptionCombos,
+    row,
+    pivot = false,
+}) => {
+    const matrix = useValueMatrix(dataElements, categoryOptionCombos, pivot)
     const rowTotal = useMemo(
         () => calculateRowTotal(matrix, row),
         [matrix, row]
@@ -42,6 +62,7 @@ export const RowTotal = ({ dataElements, categoryOptionCombos, row }) => {
 RowTotal.propTypes = {
     categoryOptionCombos: propTypes.array,
     dataElements: propTypes.array,
+    pivot: propTypes.bool,
     row: propTypes.number,
 }
 
@@ -50,8 +71,9 @@ export const ColumnTotals = ({
     paddingCells,
     dataElements,
     categoryOptionCombos,
+    pivot,
 }) => {
-    const matrix = useValueMatrix(dataElements, categoryOptionCombos)
+    const matrix = useValueMatrix(dataElements, categoryOptionCombos, pivot)
     const columnTotals = useMemo(() => calculateColumnTotals(matrix), [matrix])
 
     return (
@@ -59,12 +81,16 @@ export const ColumnTotals = ({
             <TableCellHead className={styles.totalHeader}>
                 {i18n.t('Totals')}
             </TableCellHead>
+            {pivot &&
+                paddingCells.map((_, i) =>
+                    i === 0 ? (
+                        <PaddingCell colSpan={paddingCells.length} key={i} />
+                    ) : null
+                )}
             {columnTotals.map((v, i) => (
                 <TotalCell key={i}>{v}</TotalCell>
             ))}
-            {paddingCells.map((_, i) => (
-                <TotalCell key={i} />
-            ))}
+            {!pivot && paddingCells.map((_, i) => <TotalCell key={i} />)}
             {renderTotalSum && (
                 <TotalCell>
                     {columnTotals.reduce((acc, curr) => acc + curr, 0)}
@@ -78,5 +104,6 @@ ColumnTotals.propTypes = {
     categoryOptionCombos: propTypes.array,
     dataElements: propTypes.array,
     paddingCells: propTypes.array,
+    pivot: propTypes.bool,
     renderTotalSum: propTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body/total-cells.jsx
+++ b/src/data-workspace/category-combo-table-body/total-cells.jsx
@@ -42,7 +42,7 @@ export const TotalHeader = ({ rowSpan }) => (
 )
 
 TotalHeader.propTypes = {
-    rowSpan: propTypes.number,
+    rowSpan: propTypes.string,
 }
 
 export const RowTotal = ({
@@ -81,7 +81,7 @@ export const ColumnTotals = ({
         <TableRow dataTest="dhis2-dataentry-columntotals">
             <TableCellHead
                 className={styles.totalHeader}
-                colSpan={initialColumns}
+                colSpan={initialColumns?.toString()}
             >
                 {i18n.t('Totals')}
             </TableCellHead>

--- a/src/data-workspace/category-combo-table-body/total-cells.jsx
+++ b/src/data-workspace/category-combo-table-body/total-cells.jsx
@@ -7,6 +7,8 @@ import styles from '../table-body.module.css'
 import { calculateColumnTotals, calculateRowTotal } from './calculate-totals.js'
 import { useValueMatrix } from './use-value-matrix.js'
 
+const defaultEmptyArray = []
+
 export const PaddingCell = ({ children, colSpan }) => (
     <TableCell
         className={cx('total-cell', styles.totalCell)}
@@ -49,9 +51,17 @@ export const RowTotal = ({
     dataElements,
     categoryOptionCombos,
     row,
-    pivot = false,
+    pivotType = 'none',
+    pivotedCategory,
+    categories,
 }) => {
-    const matrix = useValueMatrix(dataElements, categoryOptionCombos, pivot)
+    const matrix = useValueMatrix({
+        dataElements,
+        sortedCOCs: categoryOptionCombos,
+        pivotType,
+        pivotedCategory,
+        categories,
+    })
     const rowTotal = useMemo(
         () => calculateRowTotal(matrix, row),
         [matrix, row]
@@ -60,9 +70,11 @@ export const RowTotal = ({
 }
 
 RowTotal.propTypes = {
+    categories: propTypes.array,
     categoryOptionCombos: propTypes.array,
     dataElements: propTypes.array,
-    pivot: propTypes.bool,
+    pivotType: propTypes.oneOf(['move_categories', 'pivot', 'none']),
+    pivotedCategory: propTypes.string,
     row: propTypes.number,
 }
 
@@ -70,11 +82,19 @@ export const ColumnTotals = ({
     renderTotalSum,
     initialColumns = 1,
     paddingCells,
-    dataElements,
-    categoryOptionCombos,
-    pivot,
+    dataElements = defaultEmptyArray,
+    categoryOptionCombos = defaultEmptyArray,
+    pivotType = 'none',
+    pivotedCategory = null,
+    categories = defaultEmptyArray,
 }) => {
-    const matrix = useValueMatrix(dataElements, categoryOptionCombos, pivot)
+    const matrix = useValueMatrix({
+        dataElements,
+        sortedCOCs: categoryOptionCombos,
+        pivotType,
+        pivotedCategory,
+        categories,
+    })
     const columnTotals = useMemo(() => calculateColumnTotals(matrix), [matrix])
 
     return (
@@ -102,10 +122,12 @@ export const ColumnTotals = ({
 }
 
 ColumnTotals.propTypes = {
+    categories: propTypes.array,
     categoryOptionCombos: propTypes.array,
     dataElements: propTypes.array,
     initialColumns: propTypes.number,
     paddingCells: propTypes.array,
-    pivot: propTypes.bool,
+    pivotType: propTypes.oneOf(['move_categories', 'pivot', 'none']),
+    pivotedCategory: propTypes.string,
     renderTotalSum: propTypes.bool,
 }

--- a/src/data-workspace/category-combo-table-body/total-cells.jsx
+++ b/src/data-workspace/category-combo-table-body/total-cells.jsx
@@ -51,14 +51,6 @@ export const RowTotal = ({
     row,
     pivot = false,
 }) => {
-    // maybe move this?
-    if (pivot && row === -1) {
-        return (
-            <TableCellHead className={styles.totalHeader}>
-                {i18n.t('Totals')}
-            </TableCellHead>
-        )
-    }
     const matrix = useValueMatrix(dataElements, categoryOptionCombos, pivot)
     const rowTotal = useMemo(
         () => calculateRowTotal(matrix, row),
@@ -112,6 +104,7 @@ export const ColumnTotals = ({
 ColumnTotals.propTypes = {
     categoryOptionCombos: propTypes.array,
     dataElements: propTypes.array,
+    initialColumns: propTypes.number,
     paddingCells: propTypes.array,
     pivot: propTypes.bool,
     renderTotalSum: propTypes.bool,

--- a/src/data-workspace/category-combo-table-body/total-cells.jsx
+++ b/src/data-workspace/category-combo-table-body/total-cells.jsx
@@ -9,21 +9,6 @@ import { useValueMatrix } from './use-value-matrix.js'
 
 const defaultEmptyArray = []
 
-export const PaddingCell = ({ children, colSpan }) => (
-    <TableCell
-        className={cx('total-cell', styles.totalCell)}
-        dataTest="dhis2-dataentry-totalcell-padding"
-        colSpan={colSpan}
-    >
-        {children}
-    </TableCell>
-)
-
-PaddingCell.propTypes = {
-    children: propTypes.node,
-    colSpan: propTypes.number,
-}
-
 export const TotalCell = ({ children }) => (
     <TableCell
         className={cx('total-cell', styles.totalCell)}

--- a/src/data-workspace/category-combo-table-body/use-value-matrix.js
+++ b/src/data-workspace/category-combo-table-body/use-value-matrix.js
@@ -58,5 +58,6 @@ export const useValueMatrix = (
         dataElements,
         dataValues,
         sortedCOCs,
+        pivot,
     ])
 }

--- a/src/data-workspace/category-combo-table-body/use-value-matrix.js
+++ b/src/data-workspace/category-combo-table-body/use-value-matrix.js
@@ -2,6 +2,9 @@ import { useMemo, useRef } from 'react'
 import { useBlurredField, useValueStore } from '../../shared/index.js'
 import { getFieldId } from '../get-field-id.jsx'
 
+const transpose = (matrix) =>
+    matrix[0].map((_, colIndex) => matrix.map((row) => row[colIndex]))
+
 const createValueMatrix = (dataElements, sortedCOCs, dataValues) =>
     dataElements.map((de) =>
         sortedCOCs.map((coc) => dataValues?.[de?.id]?.[coc?.id]?.value)
@@ -13,7 +16,11 @@ const createValueMatrix = (dataElements, sortedCOCs, dataValues) =>
  * @param {*} dataElements dataElements in order as rendered in table, these are "rows"
  * @param {*} sortedCOCs categoryOptionCombos in order as rendered in table, these are the "columns"
  */
-export const useValueMatrix = (dataElements = [], sortedCOCs = []) => {
+export const useValueMatrix = (
+    dataElements = [],
+    sortedCOCs = [],
+    pivot = false
+) => {
     const valueMatrixRef = useRef(null)
     const blurredField = useBlurredField()
     const dataValues = useValueStore((state) => state.getDataValues())
@@ -39,7 +46,12 @@ export const useValueMatrix = (dataElements = [], sortedCOCs = []) => {
                 dataValues
             )
         }
-        return valueMatrixRef.current
+        if (!valueMatrixRef.current) {
+            return undefined
+        }
+        return pivot
+            ? transpose(valueMatrixRef.current)
+            : valueMatrixRef.current
     }, [
         blurredField,
         affectedFieldsLookup,

--- a/src/data-workspace/category-combo-table-body/use-value-matrix.js
+++ b/src/data-workspace/category-combo-table-body/use-value-matrix.js
@@ -5,22 +5,86 @@ import { getFieldId } from '../get-field-id.jsx'
 const transpose = (matrix) =>
     matrix[0].map((_, colIndex) => matrix.map((row) => row[colIndex]))
 
-const createValueMatrix = (dataElements, sortedCOCs, dataValues) =>
-    dataElements.map((de) =>
+/*
+    This function takes sortedCOCs and reorders such that a category is put in the "row" and other cocs are put as columns
+    // for each relevant category option
+
+    e.g.
+    /*
+        [a1, b1, c1]
+        [a1, b1, c2]
+        [a1, b1, c3]
+        [a1, b2, c1]
+        [a1, b2, c2]
+        [a1, b2, c3]
+        [a2, b1, c1]
+        [a2, b1, c2]
+        [a2, b1, c3]
+        [a2, b2, c1]
+        [a2, b2, c2]
+        [a2, b2, c3]
+        
+        [[a1, b1, c1],[a1, b1, c2],[a1, b1, c3],[a2, b1, c1],[a2, b1, c2],[a2, b1, c3]],
+        [[a1, b2, c1],[a1, b2, c2],[a1, b2, c3],[a2, b2, c1],[a2, b2, c2],[a2, b2, c3]]
+        
+        the end matrix will have shape of rows: # category options in pivoted category, columns: product of remaining category options
+        the finial result of this function is an array rows, columns of metadata ({de:id,coc:id}) in the order of the table, so that values can be retrieved
+    */
+
+const createPivotedMatrix = ({
+    categories,
+    sortedCOCs,
+    pivotType,
+    pivotedCategory,
+    dataElements,
+}) => {
+    // create map from category options to categories
+    if (!pivotedCategory || pivotType !== 'move_categories') {
+        return null
+    }
+    const pivotedCategoryOptions = categories.find(
+        (cc) => cc.id === pivotedCategory
+    )?.categoryOptions
+    if (!pivotedCategoryOptions) {
+        return null
+    }
+    const pivotedCOCs = pivotedCategoryOptions.map((pco) =>
+        sortedCOCs.filter((coc) => coc.categoryOptions.includes(pco))
+    )
+    return dataElements.flatMap((de) =>
+        pivotedCOCs.map((row) => row.map((coc) => ({ coc: coc.id, de: de.id })))
+    )
+}
+
+const createValueMatrix = ({
+    dataElements,
+    sortedCOCs,
+    dataValues,
+    pivotedMetadataMatrix,
+}) => {
+    if (pivotedMetadataMatrix) {
+        return pivotedMetadataMatrix.map((row) =>
+            row.map(({ de, coc }) => dataValues?.[de]?.[coc]?.value)
+        )
+    }
+    return dataElements.map((de) =>
         sortedCOCs.map((coc) => dataValues?.[de?.id]?.[coc?.id]?.value)
     )
-
+}
 /**
  * Generates matrix (2d-array) of the values in a table, defined by dataElements and
  * the categoryOptionCombos.
  * @param {*} dataElements dataElements in order as rendered in table, these are "rows"
  * @param {*} sortedCOCs categoryOptionCombos in order as rendered in table, these are the "columns"
+ * @param {*} pivotInfo {pivotType:'none', 'pivot', or 'move_categories', pivotedCategory, 'category' or undefined)
  */
-export const useValueMatrix = (
-    dataElements = [],
-    sortedCOCs = [],
-    pivot = false
-) => {
+export const useValueMatrix = ({
+    dataElements,
+    sortedCOCs,
+    pivotType,
+    pivotedCategory,
+    categories,
+}) => {
     const valueMatrixRef = useRef(null)
     const blurredField = useBlurredField()
     const dataValues = useValueStore((state) => state.getDataValues())
@@ -35,29 +99,45 @@ export const useValueMatrix = (
         [dataElements, sortedCOCs]
     )
 
+    const pivotedMetadataMatrix = useMemo(
+        () =>
+            createPivotedMatrix({
+                categories,
+                sortedCOCs,
+                pivotedCategory,
+                pivotType,
+                dataElements,
+            }),
+        [categories, sortedCOCs, pivotedCategory, pivotType, dataElements]
+    )
+
     return useMemo(() => {
         if (
             valueMatrixRef.current === null ||
             affectedFieldsLookup.has(blurredField)
         ) {
-            valueMatrixRef.current = createValueMatrix(
+            valueMatrixRef.current = createValueMatrix({
                 dataElements,
                 sortedCOCs,
-                dataValues
-            )
+                dataValues,
+                pivotedMetadataMatrix,
+            })
         }
         if (!valueMatrixRef.current) {
             return undefined
         }
-        return pivot
-            ? transpose(valueMatrixRef.current)
-            : valueMatrixRef.current
+        if (pivotType === 'pivot') {
+            return transpose(valueMatrixRef.current)
+        }
+        return valueMatrixRef.current
     }, [
         blurredField,
         affectedFieldsLookup,
         dataElements,
         dataValues,
         sortedCOCs,
-        pivot,
+        pivotType,
+        pivotedMetadataMatrix,
+        valueMatrixRef,
     ])
 }

--- a/src/data-workspace/category-combo-table-body/use-value-matrix.test.js
+++ b/src/data-workspace/category-combo-table-body/use-value-matrix.test.js
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react'
+import { useValueStore } from '../../shared/stores/data-value-store.js'
+import { useValueMatrix } from './use-value-matrix.js'
+
+const fakeValueStore = {
+    de1: {
+        coc1: {
+            value: '1',
+        },
+        coc2: {
+            value: 'text',
+        },
+        coc3: {
+            value: '3',
+        },
+    },
+    de2: {
+        coc2: {
+            value: '20',
+        },
+    },
+    de3: {
+        coc1: {
+            value: '100',
+        },
+        coc2: {
+            value: '200',
+        },
+        coc3: {
+            value: '300',
+        },
+    },
+}
+
+jest.mock('../../shared/stores/data-value-store', () => ({
+    useValueStore: jest.fn(),
+}))
+
+describe('useValueMatrix', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+    it('renders the matrix with DEs as rows and COCs as columns by default', () => {
+        const des = [{ id: 'de1' }, { id: 'de2' }]
+        const sortedCOCs = [{ id: 'coc1' }, { id: 'coc2' }, { id: 'coc3' }]
+        useValueStore.mockReturnValueOnce(fakeValueStore)
+
+        const { result } = renderHook(() => useValueMatrix(des, sortedCOCs))
+        expect(result.current).toEqual([
+            ['1', 'text', '3'],
+            [undefined, '20', undefined],
+        ])
+    })
+    it('renders the matrix with COCs as rows and DEs as columns if pivot=true', () => {
+        const des = [{ id: 'de1' }, { id: 'de2' }]
+        const sortedCOCs = [{ id: 'coc1' }, { id: 'coc2' }, { id: 'coc3' }]
+        useValueStore.mockReturnValueOnce(fakeValueStore)
+
+        const { result } = renderHook(() =>
+            useValueMatrix(des, sortedCOCs, true)
+        )
+        expect(result.current).toEqual([
+            ['1', undefined],
+            ['text', '20'],
+            ['3', undefined],
+        ])
+    })
+})

--- a/src/data-workspace/category-combo-table-body/use-value-matrix.test.js
+++ b/src/data-workspace/category-combo-table-body/use-value-matrix.test.js
@@ -13,10 +13,16 @@ const fakeValueStore = {
         coc3: {
             value: '3',
         },
+        coc4: {
+            value: '4',
+        },
     },
     de2: {
         coc2: {
             value: '20',
+        },
+        coc4: {
+            value: '40',
         },
     },
     de3: {
@@ -28,6 +34,9 @@ const fakeValueStore = {
         },
         coc3: {
             value: '300',
+        },
+        coc4: {
+            value: '400',
         },
     },
 }
@@ -42,27 +51,95 @@ describe('useValueMatrix', () => {
     })
     it('renders the matrix with DEs as rows and COCs as columns by default', () => {
         const des = [{ id: 'de1' }, { id: 'de2' }]
-        const sortedCOCs = [{ id: 'coc1' }, { id: 'coc2' }, { id: 'coc3' }]
+        const sortedCOCs = [
+            { id: 'coc1' },
+            { id: 'coc2' },
+            { id: 'coc3' },
+            { id: 'coc4' },
+        ]
         useValueStore.mockReturnValueOnce(fakeValueStore)
-
-        const { result } = renderHook(() => useValueMatrix(des, sortedCOCs))
+        /*
+    dataElements,
+    sortedCOCs,
+    pivotType,
+    pivotedCategory,
+    categories,
+*/
+        const { result } = renderHook(() =>
+            useValueMatrix({ dataElements: des, sortedCOCs })
+        )
         expect(result.current).toEqual([
-            ['1', 'text', '3'],
-            [undefined, '20', undefined],
+            ['1', 'text', '3', '4'],
+            [undefined, '20', undefined, '40'],
         ])
     })
     it('renders the matrix with COCs as rows and DEs as columns if pivot=true', () => {
         const des = [{ id: 'de1' }, { id: 'de2' }]
-        const sortedCOCs = [{ id: 'coc1' }, { id: 'coc2' }, { id: 'coc3' }]
+        const sortedCOCs = [
+            { id: 'coc1' },
+            { id: 'coc2' },
+            { id: 'coc3' },
+            { id: 'coc4' },
+        ]
         useValueStore.mockReturnValueOnce(fakeValueStore)
 
         const { result } = renderHook(() =>
-            useValueMatrix(des, sortedCOCs, true)
+            useValueMatrix({
+                dataElements: des,
+                sortedCOCs,
+                pivotType: 'pivot',
+            })
         )
         expect(result.current).toEqual([
             ['1', undefined],
             ['text', '20'],
             ['3', undefined],
+            ['4', '40'],
         ])
+    })
+    it('renders an appropriate partially pivoted matrix based on pivotedCategory', () => {
+        const des = [{ id: 'de1' }, { id: 'de2' }]
+        const sortedCOCs = [
+            { id: 'coc1', categoryOptions: ['catOptA', 'catOptY'] },
+            { id: 'coc2', categoryOptions: ['catOptA', 'catOptZ'] },
+            { id: 'coc3', categoryOptions: ['catOptB', 'catOptY'] },
+            { id: 'coc4', categoryOptions: ['catOptB', 'catOptZ'] },
+        ]
+        const pivotType = 'move_categories'
+        const pivotedCategory = 'cat1'
+        const categories = [
+            { id: 'cat1', categoryOptions: ['catOptA', 'catOptB'] },
+            { id: 'cat2', categoryOptions: ['catOptY', 'catOptZ'] },
+        ]
+        useValueStore.mockReturnValueOnce(fakeValueStore)
+
+        const { result } = renderHook(() =>
+            useValueMatrix({
+                dataElements: des,
+                sortedCOCs,
+                pivotType,
+                pivotedCategory,
+                categories,
+            })
+        )
+        expect(result.current).toEqual([
+            ['1', 'text'],
+            ['3', '4'],
+            [undefined, '20'],
+            [undefined, '40'],
+        ])
+
+        /*
+                    ['1','text'],
+            ['3','4'],
+            [undefined,'20'],
+            [undefined,'40'],
+            */
+        /*
+                    [de1/A/Y/coc1,de1/A/Z/coc2],
+            [de1/B/Y/coc3,de1/B/Z/coc4],
+            [de2/A/Y/coc1,de2/A/Z/coc2],
+            [de2/B/Y/coc3,de2/B/Z/coc4],   
+            */
     })
 })

--- a/src/data-workspace/section-form/section.jsx
+++ b/src/data-workspace/section-form/section.jsx
@@ -33,6 +33,12 @@ export function SectionFormSection({
 
     const { data } = useMetadata()
 
+    const displayOptions = getDisplayOptions(section)
+
+    const isPivotMode =
+        displayOptions?.pivotMode === 'move_categories' ||
+        displayOptions?.pivotMode === 'pivot'
+
     const dataElements = selectors.getDataElementsBySection(
         data,
         dataSetId,
@@ -51,6 +57,11 @@ export function SectionFormSection({
     const maxColumnsInSection = useMemo(() => {
         if (groupedDataElements.length === 0) {
             return 0
+        }
+        if (isPivotMode) {
+            return Math.max(
+                ...groupedDataElements.map((grp) => grp.dataElements.length)
+            )
         }
         const groupedTotalColumns = groupedDataElements.map((grp) =>
             selectors.getNrOfColumnsInCategoryCombo(data, grp.categoryCombo.id)
@@ -73,12 +84,6 @@ export function SectionFormSection({
 
     const filterInputId = `filter-input-${section.id}`
     const headerCellStyles = classNames(styles.headerCell, styles.hideForPrint)
-
-    const displayOptions = getDisplayOptions(section)
-
-    const isPivotMode =
-        displayOptions?.pivotMode === 'move_categories' ||
-        displayOptions?.pivotMode === 'pivot'
 
     const TableComponent = isPivotMode
         ? PivotedCategoryComboTableBody


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-19079

Adds totals for pivoted sections (e.g. DEs/CoCs are pivoted, or a specific category is pivoted).

From child health (I've removed some DEs for ease of view)

_normal_
<img width="927" height="266" alt="image" src="https://github.com/user-attachments/assets/d51afa34-34e1-47ba-bf5e-386abd51bb07" />



_pivoted_
<img width="812" height="268" alt="image" src="https://github.com/user-attachments/assets/928a0127-a475-496f-b2c9-35ad6ed4e271" />


_1 category pivoted_
<img width="659" height="356" alt="image" src="https://github.com/user-attachments/assets/da2e2048-9d27-4258-9594-7e23d68e759b" />


Note: I noticed that there is a general issue when we pivot a category in a section but the data elements have different category combos: https://dhis2.atlassian.net/browse/DHIS2-21869. As such, I have not made the totals work for this case, but think we can address as part of the general fix to that bug.