### PR TITLE
fix: first row height with vertical section tabs [DHIS2-21240]

### DIFF
--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -164,6 +164,7 @@
 
 .verticalSectionTabWrapper {
     flex-direction: row;
+    align-items: flex-start;
 }
 
 @media print {


### PR DESCRIPTION
See [DHIS2-21240](https://dhis2.atlassian.net/browse/DHIS2-21240)

Fixes first data row rendering several times taller than other rows when a section form uses "Vertical tabs" layout.


<img width="1114" height="435" alt="Screenshot 2026-07-28 at 14 53 57" src="https://github.com/user-attachments/assets/49bf7cfc-40d1-4eff-ac99-edbe9278f357" />


[DHIS2-21240]: https://dhis2.atlassian.net/browse/DHIS2-21240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ